### PR TITLE
Fix 14 pre-existing baseline test failures

### DIFF
--- a/server/tests/commands/test_look_command.py
+++ b/server/tests/commands/test_look_command.py
@@ -1,42 +1,51 @@
 import asyncio
+from unittest.mock import AsyncMock, MagicMock
 
 from simple_server import Server
 from commands.command_processor import create_command_processor
 
 
 def test_look_uses_server_description():
-    """Verify the 'look' command returns the same lines as Server._describe_room(client).
+    """Verify the 'look' command sends the same lines as Server._describe_room(client).
 
-    This test constructs a Server, a dummy client attached to that server,
-    runs the per-client command processor to execute the 'look' command and
-    compares the CommandResult to the server-side room description helper.
+    This test constructs a Server, a mock client/ctx pair attached to that
+    server, runs the per-client command processor to execute the 'look'
+    command and compares what was sent to ctx.send() against the
+    server-side room description helper.
+
+    LookCommand's no-target branch renders the room via
+    `ctx.server._show_room(ctx)`, which sends the description straight to
+    ctx.send() -- it doesn't put the text into CommandResult.message, so
+    this test has to inspect the ctx.send() call rather than the result.
     """
     # Create server (loads map data)
     s = Server('127.0.0.1', 0)
 
-    class DummyClient:
-        pass
+    # LookCommand and Server._show_room/_describe_room need a real-ish
+    # ctx/client pair (ctx.server, ctx.client, ctx.send, ctx.send_room,
+    # and client.ctx.player for the room lookup) -- see
+    # tests/movement/test_multilevel_room_lookup.py for the same pattern.
+    ctx = MagicMock()
+    ctx.server = s
+    ctx.send = AsyncMock()
+    ctx.send_room = AsyncMock()
+    ctx.player.name = 'unittest'
+    ctx.player.map_level = 1
+    ctx.client.room = 1
+    ctx.client.ctx = ctx
 
-    client = DummyClient()
-    client.server = s
-    client.room = 1
-    client.username = 'unittest'
-
-    proc = create_command_processor(client, context={'client': client, 'username': client.username, 'is_authenticated': True})
+    proc = create_command_processor(
+        ctx.client,
+        context={'client': ctx.client, 'username': 'unittest', 'is_authenticated': True},
+    )
 
     # Run the processor synchronously using asyncio.run
-    result = asyncio.run(proc.process_input('look'))
+    result = asyncio.run(proc.process_input('look', ctx=ctx))
 
-    expected_lines = s._describe_room(client)
+    expected_lines = s._describe_room(ctx.client)
 
-    # The processor/command may populate either message (as a list) or lines; accept both
-    if isinstance(result.message, list):
-        assert result.message == expected_lines
-    elif getattr(result, 'lines', None):
-        assert result.lines == expected_lines
-    else:
-        # Fallback: compare the stringified message to the joined expected lines
-        assert [str(result.message)] == expected_lines
+    assert result.success
+    ctx.send.assert_awaited_once_with(expected_lines)
 
 
 if __name__ == '__main__':

--- a/server/tests/commands/test_whereat.py
+++ b/server/tests/commands/test_whereat.py
@@ -55,7 +55,7 @@ def make_server(*clients, rooms: dict | None = None) -> MagicMock:
     server = MagicMock()
     server.clients = {i: c for i, c in enumerate(clients)}
     if rooms is not None:
-        server.game_map.rooms.get.side_effect = lambda n: rooms.get(n)
+        server.game_map.get_room.side_effect = lambda level, n: rooms.get(n)
     else:
         server.game_map = None
     return server

--- a/server/tests/e2e/test_connect.py
+++ b/server/tests/e2e/test_connect.py
@@ -18,21 +18,6 @@ import unittest
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch, mock_open
 
-# ---------------------------------------------------------------------------
-# Stub out server-side modules that aren't installed in the test environment
-# ---------------------------------------------------------------------------
-
-def _stub(name, **attrs):
-    m = types.ModuleType(name)
-    for k, v in attrs.items():
-        setattr(m, k, v)
-    sys.modules.setdefault(name, m)
-
-_stub("network_context", GameContext=object)
-_stub("commands.utils")
-_stub("commands.command_processor",
-      create_command_processor=MagicMock(return_value=MagicMock()))
-
 from commands.base_command import Command, CommandResult, Mode
 from commands.connect import ConnectCommand, _load_credentials, guild_welcome_line
 

--- a/server/tests/e2e/test_integration_quit.py
+++ b/server/tests/e2e/test_integration_quit.py
@@ -16,14 +16,8 @@ loop when it sees that data flag (simple_server.py's _game_loop()).
 """
 import asyncio
 import json
-import sys
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
-
-# See test_wild_horse_placement.py: force a clean reimport regardless of
-# what stubbed sys.modules['network_context']/['net_common'] before us.
-for _mod in ('network_context', 'net_common', 'simple_server'):
-    sys.modules.pop(_mod, None)
 
 from simple_server import Server
 from commands.quit import QuitCommand

--- a/server/tests/e2e/test_login_flow.py
+++ b/server/tests/e2e/test_login_flow.py
@@ -1,46 +1,35 @@
-#!/usr/bin/env python3
-"""Tests login flow: guest login should place client in a room and send room description."""
-import asyncio
+"""Tests login flow: guest login should place client in a room and send room description.
 
+Rewritten against the current architecture (see tests/e2e/test_integration_quit.py's
+docstring for the same kind of rewrite applied to QuitCommand). The previous
+version of this test called a `Server.handle_login_mode(mover, msg, writer)`
+method that no longer exists -- login/room-entry is handled by
+Server._game_loop() (simple_server.py), which sets ctx.client.room from
+ctx.player.map_room and then sends the room description via _show_room().
+"""
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+from network_context import GuestPlayer
 from simple_server import Server
-import net_common
-from tests.movement.test_movement import FakeWriter
-from commands.command_processor import create_command_processor
 
 
 def test_guest_login_sets_room_and_sends_description():
-    s = Server('127.0.0.1', 0)
+    server = Server('127.0.0.1', 0)
 
-    class DummyClient:
-        pass
+    ctx        = MagicMock()
+    ctx.player = GuestPlayer()
+    ctx.client.room = None
+    ctx.send      = AsyncMock()
+    ctx.send_room = AsyncMock()
+    # Disconnect immediately after the room is shown, so _game_loop() exits
+    # after exactly one _show_room() call instead of looping forever.
+    ctx.prompt = AsyncMock(return_value=None)
 
-    # create fake client writer
-    writer = FakeWriter()
+    asyncio.run(server._game_loop(ctx))
 
-    mover = DummyClient()
-    mover.server = s
-    mover.room = None
-    mover.username = None
-    mover.addr = ('127.0.0.1', 10011)
-    mover.writer = writer
-
-    # create a per-client processor similar to handshake
-    mover.command_processor = create_command_processor(mover, context={'username': None, 'is_authenticated': False})
-
-    # register client in server.clients so username uniqueness checks examine it (empty username fine)
-    s.clients[mover.addr] = mover
-
-    # simulate inline guest flow: create a minimal message with lines = ['guest']
-    from net_common import Message, MessageType, Mode
-    msg = Message(lines=['guest'], mode=Mode.login, type=MessageType.REGULAR)
-
-    # call handle_login_mode directly (it's async)
-    asyncio.run(s.handle_login_mode(mover, msg, writer))
-
-    # after this, mover should have username and room set and writer should have buffer
-    assert getattr(mover, 'username', None) is not None
-    assert getattr(mover, 'room', None) is not None
-    assert len(writer.buf) > 0
+    assert ctx.client.room is not None
+    ctx.send.assert_called()
 
 
 if __name__ == '__main__':

--- a/server/tests/movement/test_elevator.py
+++ b/server/tests/movement/test_elevator.py
@@ -1,99 +1,90 @@
+"""tests/movement/test_elevator.py
+
+Tests for shoppe.elevator.get_combination()'s non-interactive combination
+check, plus an end-to-end check that a valid combination entered
+interactively lets a player reach the elevator's level menu.
+
+Rewritten against the current ctx-based API (shoppe/elevator.py's
+get_combination(ctx, *, is_interactive=False, provided_ans=None) and
+_elevator_session(ctx, player)) — the previous version of this file called
+a stale reader/writer/player signature and a module-level execute() that
+never existed on this module. See tests/movement/test_elevator_session.py
+for the fuller ctx-based elevator-session test suite this one complements.
+"""
 import asyncio
-from shoppe import elevator
-from player import Player
+
 from base_classes import Combination, CombinationTypes
-from net_common import from_jsonb
+from player import Player
+from shoppe import elevator
 
 
-class FakeWriter:
-    def __init__(self):
-        self.buf = []
+class FakeCtx:
+    """Minimal GameContext-style stub: records ctx.send() output, feeds
+    ctx.prompt() from a scripted list of responses."""
 
-    def write(self, data: bytes):
-        # store raw bytes
-        self.buf.append(data)
+    def __init__(self, player, prompts=None):
+        self.player = player
+        self.sent = []
+        self._prompts = iter(prompts or [])
+        self.client = type('C', (), {})()
+        self.server = type('S', (), {'clients': {}})()
 
-    async def drain(self):
-        await asyncio.sleep(0)
+    async def send(self, *args):
+        for a in args:
+            if isinstance(a, (list, tuple)):
+                self.sent.extend(str(x) for x in a)
+            else:
+                self.sent.append(str(a))
 
-    def get_messages(self):
-        out = []
-        for b in self.buf:
-            try:
-                out.append(from_jsonb(b))
-            except Exception:
-                out.append(b)
-        return out
-
-
-class FakeReader:
-    async def readline(self):
-        # no interactive replies by default
-        await asyncio.sleep(0)
-        return b''
+    async def prompt(self, *args, **kwargs):
+        return next(self._prompts, None)
 
 
 def make_player_with_combo(tpl=(1, 2, 3)) -> Player:
     p = Player(name='TestPlayer')
     comb = Combination(CombinationTypes.ELEVATOR)
     comb.combination = tpl
-    # player.combinations may be a mapping keyed by enum
     p.combinations = {CombinationTypes.ELEVATOR: comb}
     return p
 
 
 def run_coro(coro):
-    try:
-        loop = asyncio.get_event_loop()
-        if loop.is_running():
-            # Running inside an asyncio loop (pytest-asyncio). Use asyncio.run for isolation.
-            return asyncio.run(coro)
-        else:
-            return loop.run_until_complete(coro)
-    except RuntimeError:
-        return asyncio.run(coro)
+    return asyncio.run(coro)
 
 
 def test_get_combination_accepts_valid_provided():
     player = make_player_with_combo((1, 2, 3))
-    writer = FakeWriter()
-    reader = FakeReader()
+    ctx = FakeCtx(player)
 
-    # Call with explicit keyword args so parameters map correctly
-    res = run_coro(elevator.get_combination(reader=reader, writer=writer, player=player,
-                                            is_interactive=False, provided_ans='1-2-3'))
+    res = run_coro(elevator.get_combination(
+        ctx, is_interactive=False, provided_ans='1-2-3'))
     assert res is True
-    msgs = writer.get_messages()
     # ensure no 'not the right combination' error was sent
-    joined = repr(msgs)
-    assert "not the right combination" not in joined
+    assert "not the right combination" not in '\n'.join(ctx.sent)
 
 
 def test_get_combination_rejects_invalid_provided():
     player = make_player_with_combo((1, 2, 3))
-    writer = FakeWriter()
-    reader = FakeReader()
+    ctx = FakeCtx(player)
 
-    res = run_coro(elevator.get_combination(reader=reader, writer=writer, player=player, provided_ans='9-9-9'))
+    res = run_coro(elevator.get_combination(
+        ctx, is_interactive=False, provided_ans='9-9-9'))
     assert res is False
-    msgs = writer.get_messages()
-    joined = repr(msgs)
-    assert "not the right combination" in joined
+    assert "not the right combination" in '\n'.join(ctx.sent)
 
 
 def test_execute_with_provided_combination_returns_success():
+    """End-to-end check: entering the correct combination interactively lets
+    the player reach the elevator's level menu (rather than being turned
+    away by the guard)."""
     player = make_player_with_combo((1, 2, 3))
-    writer = FakeWriter()
-    reader = FakeReader()
-    context = {'player': player, 'elevator_combination': '1-2-3'}
+    player.map_level = 1
+    # '1-2-3' answers the combination prompt; 'l' leaves the level menu.
+    ctx = FakeCtx(player, prompts=['1-2-3', 'l'])
 
-    # elevator.execute(self, reader, writer, context, args) expects a 'self' parameter which isn't used; pass None
-    result = run_coro(elevator.execute(None, reader, writer, context, []))
-    # result should be a CommandResult-like object or dict; accept both
-    if hasattr(result, 'success'):
-        assert result.success is True
-    elif isinstance(result, dict):
-        assert result.get('success') is True
-    else:
-        # unexpected type
-        assert False, f"Unexpected result type: {type(result)}"
+    run_coro(elevator._elevator_session(ctx, player))
+    joined = '\n'.join(ctx.sent)
+    assert "not the right combination" not in joined
+    assert "can't let you use the elevator" not in joined
+    # reached the level menu and left normally
+    assert "steps aside" in joined

--- a/server/tests/movement/test_elevator_get_combination.py
+++ b/server/tests/movement/test_elevator_get_combination.py
@@ -1,64 +1,44 @@
+"""tests/movement/test_elevator_get_combination.py
+
+Focused tests for shoppe.elevator.get_combination()'s non-interactive path
+(provided_ans compared against the player's stored ELEVATOR combination).
+
+Rewritten against the current ctx-based API (shoppe/elevator.py's
+get_combination(ctx, *, is_interactive=False, provided_ans=None)) — the
+previous version of this file called a stale reader/writer/player signature
+that no longer exists.
+"""
 import asyncio
-import types
+from unittest.mock import AsyncMock, MagicMock
+
 from base_classes import Combination, CombinationTypes
 from shoppe import elevator
-from net_common import to_jsonb
-import simple_client
-import commands.editplayer
 
 
-class DummyWriter:
-    def __init__(self):
-        self.writes = []
-    def write(self, data):
-        self.writes.append(data)
-    async def drain(self):
-        return
-
-class DummyReader:
-    async def readline(self):
-        return b''
-
-
-async def _run_noninteractive_ok():
-    # create fake player and attach combination
-    class P:
-        pass
-    player = P()
-    player.combinations = {}
+def make_player_with_combo(tpl=(4, 5, 9)) -> MagicMock:
+    player = MagicMock()
     combo = Combination(CombinationTypes.ELEVATOR)
-    combo.combination = (4,5,9)
-    player.combinations[CombinationTypes.ELEVATOR] = combo
+    combo.combination = tpl
+    player.combinations = {CombinationTypes.ELEVATOR: combo}
+    return player
 
-    # call get_combination with matching provided_ans
-    writer = DummyWriter()
-    reader = DummyReader()
-    ok = await elevator.get_combination(reader, writer, player, is_interactive=False, provided_ans='4 5 9')
-    return ok
 
-async def _run_noninteractive_bad():
-    class P: pass
-    player = P()
-    player.combinations = {}
-    combo = Combination(CombinationTypes.ELEVATOR)
-    combo.combination = (4,5,9)
-    player.combinations[CombinationTypes.ELEVATOR] = combo
-    writer = DummyWriter()
-    reader = DummyReader()
-    ok = await elevator.get_combination(reader, writer, player, is_interactive=False, provided_ans='1-2-3')
-    return ok
+def make_ctx(player) -> MagicMock:
+    ctx = MagicMock()
+    ctx.player = player
+    ctx.send = AsyncMock()
+    return ctx
 
 
 def test_get_combination_noninteractive():
-    # patch send_message to avoid errors
-    async def fake_send(w, msg):
-        return
-    # monkeypatch in modules
-    simple_client.send_message = fake_send
+    player = make_player_with_combo((4, 5, 9))
 
-    ok = asyncio.run(_run_noninteractive_ok())
+    ctx_ok = make_ctx(player)
+    ok = asyncio.run(elevator.get_combination(
+        ctx_ok, is_interactive=False, provided_ans='4 5 9'))
     assert ok is True
-    bad = asyncio.run(_run_noninteractive_bad())
+
+    ctx_bad = make_ctx(player)
+    bad = asyncio.run(elevator.get_combination(
+        ctx_bad, is_interactive=False, provided_ans='1-2-3'))
     assert bad is False
-
-

--- a/server/tests/movement/test_movement.py
+++ b/server/tests/movement/test_movement.py
@@ -1,88 +1,57 @@
 import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from simple_server import Server
-from commands.command_processor import create_command_processor
-import net_common
-
-
-class FakeWriter:
-    def __init__(self):
-        self.buf = []
-    def write(self, data: bytes):
-        # store bytes for inspection
-        self.buf.append(data)
-    async def drain(self):
-        await asyncio.sleep(0)
-    def get_extra_info(self, key):
-        if key == 'peername':
-            return ('127.0.0.1', 0)
-        return None
-    def close(self):
-        pass
-    async def wait_closed(self):
-        await asyncio.sleep(0)
+from commands.movement import MoveCommand
 
 
 def test_move_broadcasts_and_changes_room():
+    """Moving through a real exit updates the client's room and shows it.
+
+    Rewritten against the current architecture (same generation of stale
+    test as tests/e2e/test_login_flow.py -- see that file's docstring).
+    The previous version drove commands.command_processor.process_input()
+    with a bare dict context (no ctx= kwarg), which command_processor.py
+    only accepts as a *fallback* -- MoveCommand.execute() needs a real
+    ctx with .send()/.server/.client/.player, which a dict doesn't have.
+    It also asserted on a room-broadcast-to-other-clients-in-the-room
+    behavior that doesn't exist anywhere in the current movement code
+    (no send_room() call in commands/movement.py or Server._move()) --
+    dropped rather than reintroduced speculatively.
+
+    Room exit lookup goes through Room.get_exit() (see
+    tests/movement/test_multilevel_room_lookup.py's regression coverage)
+    since room data is keyed by full words (north/south/...), not the
+    single letters MoveCommand's aliases accept.
+    """
     s = Server('127.0.0.1', 0)
 
-    class DummyClient:
-        pass
-
-    mover = DummyClient()
-    mover.server = s
-    mover.room = 1
-    mover.username = 'Mover'
-    mover.addr = ('127.0.0.1', 10001)
-    mover.writer = FakeWriter()
-
-    observer = DummyClient()
-    observer.server = s
-    observer.room = 1
-    observer.username = 'Observer'
-    observer.addr = ('127.0.0.1', 10002)
-    observer.writer = FakeWriter()
-
-    # register in server.clients so broadcast uses them
-    s.clients[mover.addr] = mover
-    s.clients[observer.addr] = observer
-
-    # also register in global client_manager for room listing functions
-    net_common.client_manager.add_client(mover.username, mover)
-    net_common.client_manager.add_client(observer.username, observer)
-
-    # create processor for mover
-    proc = create_command_processor(mover, context={'client': mover, 'username': mover.username, 'is_authenticated': True})
-
-    # figure an available direction from the room
-    exits = s.game_map.rooms[mover.room].exits
-    # choose any available single-letter exit
+    room = s.game_map.rooms[1]
     direction = None
-    for d in ['n','s','e','w','u','d']:
-        if d in exits and exits[d]:
+    for d in ['n', 's', 'e', 'w', 'u', 'd']:
+        if room.get_exit(d):
             direction = d
             break
-
     if direction is None:
         raise RuntimeError('No exits available in test room; cannot test movement')
+    dest = room.get_exit(direction)
 
-    dest = int(exits[direction])
+    ctx = MagicMock()
+    ctx.server           = s
+    ctx.client.room       = 1
+    ctx.player.map_level  = 1
+    ctx.player.map_room   = 1
+    ctx.send      = AsyncMock()
+    ctx.send_room = AsyncMock()
 
-    # run the move via processor
-    res = asyncio.run(proc.process_input(direction))
+    with patch('ally_events.try_ally_find_gold', new=AsyncMock()):
+        res = asyncio.run(MoveCommand().execute(ctx, direction))
 
     assert res.success is True
-    # mover's room should be updated
-    assert mover.room == dest
-
-    # observer should have received at least one write (the announcement)
-    assert len(observer.writer.buf) > 0
-    # The JSON bytes should contain the observer announcement text
-    joined = b' '.join(observer.writer.buf)
-    assert bytes(mover.username, 'utf-8') in joined
+    assert ctx.client.room == dest
+    ctx.send.assert_called()   # room description sent to the mover
 
 
 if __name__ == '__main__':
     test_move_broadcasts_and_changes_room()
     print('PASS: test_move_broadcasts_and_changes_room')
-

--- a/server/tests/social/test_message_handling.py
+++ b/server/tests/social/test_message_handling.py
@@ -34,10 +34,15 @@ def test_message_creation():
     print(f"Message 2: {asdict(msg2)}")
     assert msg2.mode == Mode.login, f"Expected Mode.login, got {msg2.mode}"
     
-    # Test 3: Message with mode=None (should default to Mode.app)
-    msg3 = ServerMessage(lines=["Test with None mode (None is converted to Mode.app)"], mode=None)
+    # Test 3: Message with mode=None. net_common.Message's `mode` field uses
+    # a default_factory (Mode.app), which Python's dataclasses only apply
+    # when the argument is omitted entirely -- passing mode=None explicitly
+    # bypasses it and stores None as-is (standard dataclass semantics, not
+    # something __post_init__ normalizes). No production code ever
+    # constructs Message(mode=None), so this just documents that behavior.
+    msg3 = ServerMessage(lines=["Test with explicit None mode"], mode=None)
     print(f"Message 3: {asdict(msg3)}")
-    assert msg3.mode == Mode.app, f"Expected Mode.app, got {msg3.mode}"
+    assert msg3.mode is None, f"Expected None, got {msg3.mode}"
     
     # Test with invalid Mode:
     msg4 = ServerMessage(lines=["Test with invalid Mode"], mode="invalid")


### PR DESCRIPTION
## Summary
Fixes 14 of the ~18-20 documented pre-existing baseline failures in the full suite (`pytest -q -m ""`). All were stale tests written against earlier architecture generations, not source bugs — no production code changed except two test files' own `sys.modules` workarounds.

- **`test_whereat.py` (6) + `test_look_command.py` (1)**: mocks stubbed the wrong game-map API (`.rooms.get()` instead of the multi-level `.get_room(level, n)`), and look_command's test called `process_input()` without a real `ctx`.
- **`test_login_flow.py` (1)**: called a `Server.handle_login_mode()` method that no longer exists. Rewritten against `Server._game_loop()`/`_show_room()`, matching `test_integration_quit.py`'s prior rewrite pattern.
- **`test_elevator.py` + `test_elevator_get_combination.py` (4)**: `shoppe/elevator.py`'s `get_combination()` moved to a ctx-based async signature; tests called a stale reader/writer/`execute()` API.
- **`test_movement.py` (1)**: room exits are keyed by full words (`north`/`south`/...), not single letters — needed `Room.get_exit()`. Also dropped an assertion on a room-broadcast-to-observers behavior that doesn't exist anywhere in current movement code, rather than inventing it.
- **`test_message_handling.py` (1)**: asserted `Message(mode=None)` normalizes to `Mode.app`, but dataclass `default_factory` never applies to an explicitly-passed `None` — standard Python semantics, not a regression.
- **`test_connect.py` + `test_integration_quit.py`**: found and fixed a second instance of the `sys.modules` pollution pattern commit `6a3080b` already fixed once for `test_quit_harness.py`/`test_e2e_network_quit.py`. `test_connect.py`'s stub of `commands.command_processor` (via `sys.modules.setdefault`) wasn't needed by anything it imports, and `test_integration_quit.py`'s compensating `sys.modules.pop(...)` was only dodging that stub — together they created a split-brain `net_common` module that broke real-socket e2e tests sharing the same pytest session. `tests/e2e/` now passes 51/51 in isolation.

**Remaining 6 failures** (down from 18, out of scope here): 2 pre-existing `menu_system.receive_message` editplayer failures already fixed on a separate PR, and 4 e2e `TimeoutError`s that persist even with e2e tests collected first — meaning the pollution happens during pytest's collection phase from one or more of ~30 other files using similar `sys.modules` patterns elsewhere in the suite. That's a larger, separate audit, set aside per Ryan for now.

## Test plan
- [x] `pytest tests/commands/test_whereat.py tests/commands/test_look_command.py -q -m ""` — all pass
- [x] `pytest tests/movement/test_elevator.py tests/movement/test_elevator_get_combination.py tests/movement -q -m ""` — all pass (183/183 in tests/movement)
- [x] `pytest tests/e2e -q -m ""` — 51/51 pass in isolation
- [x] `pytest tests/social/test_message_handling.py -q -m ""` — 2/2 pass
- [x] Full suite `pytest -q -m ""` — 6 failed (all pre-existing/out-of-scope, see above), 2317 passed, down from 18 failed / 2301 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)