### PR TITLE
Fix e2e login helpers hanging on paginated login banner

### DIFF
--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -116,6 +116,51 @@ async def answer_terminal_negotiation(reader, writer, choice: str = 'A') -> None
     await send_message(writer, Message(lines=[choice], mode=Mode.app))
 
 
+async def _skip_login_banner_pagination(reader, writer) -> None:
+    """Advance past the pre-login ANSI banner's '-- More/End [n/m] --' pages.
+
+    f31b6e7 added a login banner long enough that _login()'s ctx.send(*banner)
+    now paginates (network_context.py's _paginate()) before the
+    'connect <user> <pass>' prompt ever appears -- each page blocks on its own
+    ctx.prompt() read, waiting for literally any input to continue. Without
+    this, a helper that fires 'connect ...' right after the terminal-type
+    answer has that message silently consumed as a page-continue keystroke
+    instead, and the real connect command is never seen -- the server then
+    hangs forever on the next prompt() read, which is what timed out here.
+
+    There's also a stale message to drain first: answer_terminal_negotiation()
+    never reads back ctx.prompt()'s own 'Terminal type [A/P/C/Q]' message (it
+    only sends 'A' and moves on), so that message is always still sitting
+    unread in the socket when this is called. We can't just stop at the
+    first non-pagination message either -- 'ANSI color mode set.' and the
+    banner art itself are non-pagination messages that arrive before the
+    pagination prompts do. Instead, keep draining until we've seen the
+    login menu text ("Type 'connect ...") and then the one real login
+    prompt that follows it.
+    """
+    from simple_client import send_message, receive_message
+    from net_common import Message, Mode
+
+    seen_login_menu = False
+    while True:
+        msg = await receive_message(reader)
+        if not msg:
+            return
+        lines = msg.get('lines') if isinstance(msg, dict) else None
+        prompt = msg.get('prompt') if isinstance(msg, dict) else None
+
+        if isinstance(prompt, str) and ('-- More' in prompt or '-- End' in prompt):
+            await send_message(writer, Message(lines=[''], mode=Mode.app))
+            continue
+
+        if lines and any(isinstance(ln, str) and "Type 'connect" in ln for ln in lines):
+            seen_login_menu = True
+            continue
+
+        if seen_login_menu:
+            return
+
+
 async def perform_login_as_guest(reader, writer, timeout: float = 3.0) -> str | None:
     """Complete handshake + terminal negotiation, then log in as a guest.
 
@@ -134,6 +179,7 @@ async def perform_login_as_guest(reader, writer, timeout: float = 3.0) -> str | 
 
     await perform_handshake(reader, writer)
     await answer_terminal_negotiation(reader, writer)
+    await _skip_login_banner_pagination(reader, writer)
     await send_message(writer, Message(lines=['connect guest'], mode=Mode.login))
 
     assigned_username = None
@@ -195,6 +241,7 @@ async def perform_login(reader, writer, username: str, password: str,
 
     await perform_handshake(reader, writer)
     await answer_terminal_negotiation(reader, writer)
+    await _skip_login_banner_pagination(reader, writer)
     await send_message(writer, Message(lines=[f'connect {username} {password}'], mode=Mode.login))
 
     start = time.time()


### PR DESCRIPTION
## Summary
- `f31b6e7` added an ANSI login banner long enough that `_login()`'s `ctx.send(*banner)` now paginates (`network_context.py`'s `_paginate()`, '-- More/End [n/m] --' prompts) before the login prompt appears.
- The e2e test helpers in `tests/conftest.py` (`perform_login`/`perform_login_as_guest`) fired `connect <user> <pass>` immediately after the terminal-negotiation answer, so that message got silently consumed as a page-continue keystroke instead of the real connect command — the server then hung forever on the next prompt read.
- This has been failing "Server E2E Tests" on every push to master since ~2026-08-20 (`test_network_e2e_real_login.py`, `test_network_e2e_reconnect.py`, `test_abrupt_disconnect.py`, `test_move_south_room1.py`, `test_duel_disconnect_forfeit_e2e.py`).

Added `_skip_login_banner_pagination()`, which drains the stale terminal-negotiation prompt echo (also never consumed), responds to any More/End pagination prompts with a blank continuation, and stops once past the real login menu — so the connect command is sent into a clean state.

## Test plan
- [x] `pytest -q -m "" tests/e2e/ tests/movement/test_move_south_room1.py` — 56 passed
- [x] `pytest -q -m ""` (full suite) — 4279 passed, 2 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)