### PR TITLE
news: render header/listing dates in player's PREFS date format

### DIFF
--- a/server/commands/news.py
+++ b/server/commands/news.py
@@ -109,14 +109,24 @@ class NewsCommand(Command):
                     return CommandResult.ok('No news.')
 
                 rule_width = getattr(getattr(ctx.player, 'client_settings', None), 'screen_columns', 80)
+                # Dates are rendered in the viewer's PREFS date format (which
+                # can be wider than ISO's fixed 10 chars), so size the Date
+                # column to the widest one actually shown, with _DATE_COL_WIDTH
+                # as the floor.
+                rows = [
+                    (f"{it['id']:>3}",
+                     news_store.format_posted_date(it.get('posted_at', ''), ctx.player),
+                     it.get('title', '(untitled)'))
+                    for it in visible
+                ]
+                date_col = max([_DATE_COL_WIDTH] + [len(posted) + 3 for _, posted, _ in rows])
                 lines = [
                     '', '|yellow|News|reset|', '',
-                    f"  Num  {'Date':<{_DATE_COL_WIDTH}}Title",
+                    f"  Num  {'Date':<{date_col}}Title",
                     make_rule(rule_width, hrule_char(ctx)),
                 ]
-                for it in visible:
-                    posted = it.get('posted_at', '')[:10]
-                    lines.append(f"  {it['id']:>3}. {posted:<{_DATE_COL_WIDTH}}{it.get('title', '(untitled)')}")
+                for num, posted, title in rows:
+                    lines.append(f"  {num}. {posted:<{date_col}}{title}")
                 lines.append('')
 
                 raw = await ctx.prompt(

--- a/server/news.py
+++ b/server/news.py
@@ -38,7 +38,7 @@ import logging
 from pathlib import Path
 from typing import Optional
 
-from formatting import deserialize_lines, render_lines
+from formatting import deserialize_lines, format_player_datetime, render_lines
 
 log = logging.getLogger(__name__)
 
@@ -149,11 +149,45 @@ _HEADER_COLORS_BY_POSITION = ('cyan', 'light_green')
 _HEADER_FALLBACK_COLOR = 'yellow'
 
 
-def _format_lifetime(item: dict) -> str:
+def format_posted_date(posted_at: Optional[str], player) -> str:
+    """Render a stored ISO ``posted_at`` as a date string in *player*'s
+    PREFS date format / timezone (commands/prefs.py's 'D'/'Z' rows), the
+    same way the login banner's "You last connected on ..." line does.
+
+    Falls back to the bare ``YYYY-MM-DD`` ISO prefix if the value can't be
+    parsed (e.g. an old record with a date-only or malformed stamp).
+    """
+    try:
+        dt = datetime.datetime.fromisoformat(posted_at or '')
+    except (ValueError, TypeError):
+        return (posted_at or '')[:10]
+    return format_player_datetime(dt, player)
+
+
+def _format_range_date(value: Optional[str], player) -> str:
+    """Render a range window's start/end date (a pure calendar date,
+    ``YYYY-MM-DD``) in *player*'s PREFS date format. Unlike
+    format_posted_date() this does *not* do timezone conversion -- the
+    window bounds are calendar dates, not instants, so shifting them by a
+    UTC offset would be wrong."""
+    d = _parse_iso_date(value)
+    if d is None:
+        return value or ''
+    if player is None:
+        return d.isoformat()
+    cs = getattr(player, 'client_settings', None)
+    date_format = getattr(cs, 'date_format', '') or '%B %d, %Y'
+    try:
+        return d.strftime(date_format)
+    except (ValueError, TypeError):
+        return d.isoformat()
+
+
+def _format_lifetime(item: dict, player=None) -> str:
     lifetime = item.get('lifetime', 'permanent')
     if lifetime == 'range':
-        start = item.get('start_date', '?')
-        end = item.get('end_date') or 'open-ended'
+        start = _format_range_date(item.get('start_date'), player) or '?'
+        end = _format_range_date(item.get('end_date'), player) or 'open-ended'
         return f'{start} to {end}'
     return lifetime.capitalize()
 
@@ -169,8 +203,8 @@ def format_item(item: dict, ctx) -> list[str]:
     column, same cyan/light_green/yellow-fallback coloring by line
     position -- so NEWS reads consistently with BOARD."""
     fields = [
-        ('Date',      item.get('posted_at', '')[:10]),
-        ('Lifetime',  _format_lifetime(item)),
+        ('Date',      format_posted_date(item.get('posted_at', ''), ctx.player)),
+        ('Lifetime',  _format_lifetime(item, ctx.player)),
         ('Posted By', item.get('author', '???')),
         ('Subject',   item.get('title', '(untitled)')),
     ]

--- a/server/tests/social/test_news.py
+++ b/server/tests/social/test_news.py
@@ -144,6 +144,29 @@ class TestFormatItem(unittest.TestCase):
         self.assertIn('Server Update', lines[3])
         self.assertEqual(lines[4:], ['Line one.', 'Line two.'])
 
+    def test_header_date_uses_player_date_format(self):
+        item = {'title': 'T', 'body': ['x'], 'lifetime': 'permanent',
+                'posted_at': '2026-01-02T09:30:00'}
+        ctx = MagicMock()
+        ctx.player.client_settings.screen_columns = 80
+        ctx.player.client_settings.date_format = '%m/%d/%Y'
+        ctx.player.client_settings.time_format = '%H:%M'
+        ctx.player.client_settings.timezone = ''
+        date_line = format_item(item, ctx)[0]
+        self.assertIn('01/02/2026', date_line)
+        self.assertNotIn('2026-01-02', date_line)
+
+    def test_range_lifetime_dates_use_player_date_format(self):
+        item = {'title': 'T', 'body': ['x'], 'lifetime': 'range',
+                'start_date': '2026-07-01', 'end_date': '2026-07-31',
+                'posted_at': '2026-06-01T00:00:00'}
+        ctx = MagicMock()
+        ctx.player.client_settings.screen_columns = 80
+        ctx.player.client_settings.date_format = '%m/%d/%Y'
+        ctx.player.client_settings.timezone = ''
+        lifetime_line = format_item(item, ctx)[1]
+        self.assertIn('07/01/2026 to 07/31/2026', lifetime_line)
+
     def test_centered_body_rerenders_per_viewer_screen_width(self):
         # The whole point of storing 'body' as structured Line dicts
         # instead of pre-rendered strings: the same saved item displays

--- a/server/tests/social/test_news_command.py
+++ b/server/tests/social/test_news_command.py
@@ -22,11 +22,20 @@ def run(coro):
     return asyncio.run(coro)
 
 
+class _FakeClientSettings:
+    def __init__(self, date_format='', time_format='', timezone='', screen_columns=80):
+        self.date_format = date_format
+        self.time_format = time_format
+        self.timezone = timezone
+        self.screen_columns = screen_columns
+
+
 class _FakePlayer:
-    def __init__(self, name='alexa', admin=False):
+    def __init__(self, name='alexa', admin=False, date_format=''):
         self.name = name
         self._admin = admin
         self.return_key = 'Enter'
+        self.client_settings = _FakeClientSettings(date_format=date_format)
 
     def query_flag(self, flag):
         if flag == PlayerFlags.ADMIN:
@@ -74,11 +83,21 @@ class TestList(NewsCommandTestCase):
     def test_listing_shows_date_before_title(self):
         self._seed([{'id': 1, 'title': 'Patch Notes', 'body': ['x'],
                       'lifetime': 'permanent', 'posted_at': '2026-01-01T00:00:00'}])
-        ctx = make_ctx(prompts=[''])
+        ctx = make_ctx(player=_FakePlayer(date_format='%Y-%m-%d'), prompts=[''])
         run(NewsCommand().execute(ctx))
         preamble = ctx.prompt.call_args.kwargs['preamble_lines']
         row = next(l for l in preamble if 'Patch Notes' in l)
         self.assertLess(row.index('2026-01-01'), row.index('Patch Notes'))
+
+    def test_listing_date_respects_player_date_format(self):
+        self._seed([{'id': 1, 'title': 'Patch Notes', 'body': ['x'],
+                      'lifetime': 'permanent', 'posted_at': '2026-01-02T00:00:00'}])
+        ctx = make_ctx(player=_FakePlayer(date_format='%m/%d/%Y'), prompts=[''])
+        run(NewsCommand().execute(ctx))
+        preamble = ctx.prompt.call_args.kwargs['preamble_lines']
+        row = next(l for l in preamble if 'Patch Notes' in l)
+        self.assertIn('01/02/2026', row)
+        self.assertNotIn('2026-01-02', row)
 
     def test_listing_has_header_row_and_rule(self):
         self._seed([{'id': 1, 'title': 'Patch Notes', 'body': ['x'],


### PR DESCRIPTION
## Problem

NEWS showed every date as a raw ISO `YYYY-MM-DD` prefix of the stored `posted_at`, ignoring the player's PREFS date-format / timezone choice (`commands/prefs.py` `D`/`Z` rows) that the rest of TADA honors (e.g. the login banner's "You last connected on …" line).

## Changes

- **`news.format_posted_date(posted_at, player)`** — new helper rendering a stored ISO stamp via `formatting.format_player_datetime()`, matching the login banner. Used by `format_item()`'s Date field. Falls back to the ISO prefix on unparseable stamps.
- **`_format_lifetime(item, player=None)`** — now takes the viewing player; range-window start/end dates render in the player's date format too, via `_format_range_date()` (format string only, no timezone shift — window bounds are calendar dates, not instants).
- **`commands/news.py` listing** — the Date column renders per-player and its width grows to the widest formatted date, with `_DATE_COL_WIDTH` as the floor (friendly formats like "January 01, 2026" exceed ISO's fixed 10 chars).

## Tests

Added coverage in `test_news.py` (header date + range-lifetime dates honor `date_format`) and `test_news_command.py` (listing column honors `date_format`); gave the command test's `_FakePlayer` a `client_settings` and updated the one assertion that hard-coded an ISO date. All 50 news tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)