### PR TITLE
Add say #verb and #split/#unsplit switches

### DIFF
--- a/server/command_settings.py
+++ b/server/command_settings.py
@@ -80,6 +80,26 @@ class TeleportSettings:
 
 
 @dataclass
+class SaySettings:
+    """commands/say.py preferences.
+
+    split: False (default) shows the whole line as one quote. True: a
+    ',,' in the text splits it into a mid-sentence attribution, e.g.
+    'say This is something,,up with which I will not put!' becomes
+    '"This is something," you exclaim, "up with which I will not put!"'
+
+    verb: None (default) picks the verb from trailing punctuation (says/
+    asks/exclaims/mutters). Set via 'say #verb=<word>' to always use that
+    word instead (e.g. verb='grumble' -> 'Rulan grumbles, "..."');
+    'say #verb=off' (or '#verb=' / '#verb=none') clears it back to
+    punctuation-based selection. 'say #verb' (bare) previews the current
+    verb without broadcasting anything.
+    """
+    split: bool = False
+    verb: Optional[str] = None
+
+
+@dataclass
 class CommandSettings:
     """Player-controlled command preferences."""
     whereat_hidden: bool = False
@@ -103,6 +123,9 @@ class CommandSettings:
     # False (default): bare movement letters are n/s/e/w (compass).
     # True: w/a/s/d instead, mapped to north/west/south/east (commands/movement.py).
     wasd_movement: bool = False
+    # 'say' preferences: comma-split dialogue attribution, custom verb
+    # override (commands/say.py)
+    say: SaySettings = field(default_factory=SaySettings)
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -114,6 +137,7 @@ class CommandSettings:
         board_data = known.pop('board', None)
         news_data = known.pop('news', None)
         teleport_data = known.pop('teleport', None)
+        say_data = known.pop('say', None)
         instance = cls(**known)
         if isinstance(tips_data, dict):
             instance.tips = TipsSettings(**{
@@ -137,4 +161,9 @@ class CommandSettings:
             instance.teleport = TeleportSettings(
                 destinations={k: tuple(v) for k, v in destinations.items()}
             )
+        if isinstance(say_data, dict):
+            instance.say = SaySettings(**{
+                k: v for k, v in say_data.items()
+                if k in SaySettings.__dataclass_fields__
+            })
         return instance

--- a/server/commands/prefs.py
+++ b/server/commands/prefs.py
@@ -26,6 +26,9 @@ Settings managed here
                       client_settings.colors.highlight_color
   N  News Display     command_settings.news.show_all  (New only / Full directory)
   W  Movement Keys    command_settings.wasd_movement  (Compass / WASD)
+  Y  Say Split        command_settings.say.split      (On / Off) — a ',,'
+                      in a 'say' splits it into a mid-sentence attribution
+                      (commands/say.py)
   T  Client Type      client_settings.screen_columns/screen_rows/translation
                       — presets (C64/C128/TADA client) or a custom size.
                         Available over a real PETSCII connection too (a
@@ -143,6 +146,16 @@ _SETTING_HELP: dict[str, list[str]] = {
         "for north/west/south/east instead (u still means Up). Full "
         "words (north, south, ...) and 'go <direction>' always work "
         "either way.",
+        '',
+    ],
+    'y': [
+        '',
+        '|cyan|Say Split|reset|',
+        "If enabled, a ',,' inside a SAY splits the line into a "
+        'mid-sentence attribution instead of one leading quote: '
+        '\'say This is something,,up with which I will not put!\' shows '
+        'as "This is something," you exclaim, "up with which I will not '
+        'put!" instead of "You exclaim, ...". Off by default.',
         '',
     ],
 }
@@ -444,8 +457,10 @@ async def prefs_menu(ctx, from_new_player: bool = False) -> bool:
         wasd = getattr(ctx.player.command_settings, 'wasd_movement', False)
         t.add_row(['W', 'Movement Keys',
                    'Inverted T (WASD)' if wasd else 'Compass directions (N/E/S/W)', 'hw'])
+        say_split = getattr(ctx.player.command_settings.say, 'split', False)
+        t.add_row(['Y', 'Say Split', 'On' if say_split else 'Off', 'hy'])
 
-        valid_keys = ['X', 'M', 'P', 'C', 'N', 'T', 'D', 'W']
+        valid_keys = ['X', 'M', 'P', 'C', 'N', 'T', 'D', 'W', 'Y']
         keys_str   = ' '.join(valid_keys)
         return_key = getattr(cs, 'return_key', 'Enter')
         menu = (
@@ -487,6 +502,8 @@ async def prefs_menu(ctx, from_new_player: bool = False) -> bool:
                       'format, hourglass clock)'),
                 ('W', 'Toggle Movement Keys (Compass directions / '
                       'Inverted T WASD)'),
+                ('Y', "Toggle Say Split (',,' in a say splits into a "
+                      "mid-sentence attribution)"),
             ]
             help_lines = (
                 ['', '|yellow|PREFS Options|reset|', '']
@@ -553,6 +570,12 @@ async def prefs_menu(ctx, from_new_player: bool = False) -> bool:
             cs3 = ctx.player.command_settings
             cs3.wasd_movement = not getattr(cs3, 'wasd_movement', False)
             await ctx.send(f"{option}{'|green|Inverted T (WASD)' if cs3.wasd_movement else '|green|Compass directions (N/E/S/W)'}|reset|")
+
+        elif ans == 'y':
+            option = "|white|Say Split: "
+            say_settings = ctx.player.command_settings.say
+            say_settings.split = not getattr(say_settings, 'split', False)
+            await ctx.send(f"{option}{'|green|On' if say_settings.split else '|red|Off'}|reset|")
 
         else:
             await ctx.send(f'Choose {",".join(valid_keys)}, or press {return_key} to save and exit.')

--- a/server/commands/say.py
+++ b/server/commands/say.py
@@ -104,7 +104,13 @@ class SayCommand(Command):
             "Broadcasts a message to all players in your room. "
             "The verb changes based on punctuation: "
             "? = asks, ! = exclaims, ... = mutters, otherwise says. "
-            'The " shortcut works without typing "say" first.'
+            'The " shortcut works without typing "say" first. '
+            "'say #verb=<word>' sets a permanent custom verb instead, "
+            "overriding punctuation entirely -- 'say #verb' previews it, "
+            "'say #verb=off' clears it. With Say Split turned on in PREFS "
+            "('Y'), a ',,' in your message splits it into a mid-sentence "
+            "attribution, and a ',,,' attaches a one-off verb right after "
+            "the quote instead."
         ),
         category = HelpCategory.COMMUNICATION,
         usage    = [
@@ -142,6 +148,11 @@ class SayCommand(Command):
                                     "'say #verb' alone previews the current verb "
                                     "without saying anything, and 'say #verb=off' "
                                     'clears it.'),
+        ],
+        notes = [
+            "Say Split (PREFS 'Y') must be on for ',,' and ',,,' to do "
+            "anything special -- otherwise they're just literal commas.",
+            "'say #verb=off' also accepts 'say #verb=' and 'say #verb=none'.",
         ],
     )
 

--- a/server/commands/say.py
+++ b/server/commands/say.py
@@ -8,6 +8,23 @@ Verb is chosen by terminal punctuation:
 
 The command is also triggered by the bare " shortcut:
   "Hello there!   →  Rulan exclaims, "Hello there!"
+
+With command_settings.say.split enabled (PREFS 'Y'), a ',,' in the text
+splits it into a mid-sentence attribution instead of one leading quote:
+  say This is something,,up with which I will not put!
+    →  "This is something," Rulan exclaims, "up with which I will not put!"
+
+A ',,,' instead attaches a one-off verb straight after the quote, in
+"<verb> <name>." order, overriding punctuation-based selection for just
+that line (doesn't touch command_settings.say.verb):
+  say Argh!,,,moan
+    →  "Argh!" moans Rulan.
+
+'say #verb=<word>' overrides the punctuation-based verb entirely
+(command_settings.say.verb), e.g. 'say #verb=grumble' then 'say Hello'
+  →  Rulan grumbles, "Hello"
+'say #verb=off' (or '#verb='/'#verb=none') clears it. Bare 'say #verb'
+previews the current verb without broadcasting anything.
 """
 from commands.base_command import Command, CommandResult, Mode
 from commands.help import Help, HelpCategory
@@ -34,6 +51,26 @@ def _choose_verb(text: str):
         if stripped.endswith(suffix):
             return verbs
     return _DEFAULT_VERB
+
+
+def _third_person(verb: str) -> str:
+    """Naive English 3rd-person-singular conjugation for a custom verb,
+    e.g. 'grumble' -> 'grumbles', 'hiss' -> 'hisses', 'cry' -> 'cries'."""
+    if verb.endswith(('s', 'sh', 'ch', 'x', 'z')):
+        return verb + 'es'
+    if verb.endswith('y') and not verb.endswith(('ay', 'ey', 'iy', 'oy', 'uy')):
+        return verb[:-1] + 'ies'
+    return verb + 's'
+
+
+def _resolve_verb(ctx: GameContext, text: str):
+    """Return (third_person, first_person) verb, preferring a custom
+    command_settings.say.verb override ('say #verb=<word>') over the
+    default punctuation-based selection."""
+    custom = getattr(ctx.player.command_settings.say, 'verb', None)
+    if custom:
+        return _third_person(custom), custom
+    return _choose_verb(text)
 
 
 # ---------------------------------------------------------------------------
@@ -71,8 +108,13 @@ class SayCommand(Command):
         ),
         category = HelpCategory.COMMUNICATION,
         usage    = [
-            ('say <message>', 'Speak aloud to everyone in the room'),
-            ('"<message>',    'Shorthand for say'),
+            ('say <message>',        'Speak aloud to everyone in the room'),
+            ('"<message>',           'Shorthand for say'),
+            ('say <msg>,,<msg2>',    "Split into a mid-sentence attribution (Say Split, PREFS 'Y')"),
+            ('say <msg>,,,<verb>',   'One-off verb straight after the quote (Say Split, PREFS \'Y\')'),
+            ('say #verb=<word>',     'Always use <word> as your say verb'),
+            ('say #verb',            'Preview your current say verb'),
+            ('say #verb=off',        'Clear the custom verb'),
         ],
         examples = [
             ('say Hello there!',   'SAY broadcasts a message to everyone in your room, '
@@ -84,11 +126,31 @@ class SayCommand(Command):
             ('"See you around.',   'The \'"\' shortcut works without typing \'say\' first '
                                     "-- with no special punctuation at the end, it's just "
                                     'Rulan says, "See you around."'),
+            ('say This is something,,up with which I will not put!',
+             "If you've turned on Say Split in PREFS ('Y'), a ',,' splits your "
+             'message into a mid-sentence attribution instead of one leading '
+             'quote -- shows as "This is something," Rulan exclaims, "up with '
+             'which I will not put!"'),
+            ('say Argh!,,,moan',   "With Say Split on, a ',,,' attaches a one-off verb "
+                                    'right after the quote instead of a mid-sentence split '
+                                    '-- shows as "Argh!" moans Rulan., overriding the '
+                                    "punctuation-based verb for just this line without "
+                                    "touching your saved #verb."),
+            ('say #verb=grumble',   "Sets your say verb permanently -- afterward, "
+                                    '"say Hello" shows as Rulan grumbles, "Hello", '
+                                    'overriding the punctuation-based verb entirely. '
+                                    "'say #verb' alone previews the current verb "
+                                    "without saying anything, and 'say #verb=off' "
+                                    'clears it.'),
         ],
     )
 
     async def execute(self, ctx: GameContext, *args) -> CommandResult:
-        args, _switches = self.parse_args(*args)
+        args, switches = self.parse_args(*args)
+
+        verb_switch = next((s for s in switches if s == '#verb' or s.startswith('#verb=')), None)
+        if verb_switch is not None:
+            return await self._handle_verb_switch(ctx, verb_switch)
 
         # Reconstruct the message; strip a leading " if the shortcut was used
         text = ' '.join(args).lstrip('"').strip()
@@ -97,10 +159,57 @@ class SayCommand(Command):
             await ctx.send('Say what?')
             return CommandResult(False, 'No message.')
 
-        third, first = _choose_verb(text)
         name = ctx.player.name
+        split_enabled = getattr(ctx.player.command_settings.say, 'split', False)
 
-        await ctx.send(f'You {first}, "{text}"')
-        await ctx.send_room(f'{name} {third}, "{text}"', exclude_self=True)
+        if split_enabled and ',,,' in text:
+            quote, _, inline_verb = text.partition(',,,')
+            quote, inline_verb = quote.strip(), inline_verb.strip()
+            if inline_verb:
+                third = _third_person(inline_verb)
+                await ctx.send(f'"{quote}" you {inline_verb}.')
+                await ctx.send_room(f'"{quote}" {third} {name}.', exclude_self=True)
+                await _gollum_riddle_check(ctx, quote)
+                return CommandResult.ok()
+            text = quote  # trailing ',,,' with no verb -- fall through as plain text
+
+        third, first = _resolve_verb(ctx, text)
+
+        if split_enabled and ',,' in text:
+            part1, part2 = (p.strip() for p in text.split(',,', 1))
+            await ctx.send(f'"{part1}," you {first}, "{part2}"')
+            await ctx.send_room(f'"{part1}," {name} {third}, "{part2}"', exclude_self=True)
+        else:
+            await ctx.send(f'You {first}, "{text}"')
+            await ctx.send_room(f'{name} {third}, "{text}"', exclude_self=True)
         await _gollum_riddle_check(ctx, text)
+        return CommandResult.ok()
+
+    async def _handle_verb_switch(self, ctx: GameContext, switch: str) -> CommandResult:
+        """'say #verb' (preview), 'say #verb=<word>' (set), or
+        'say #verb=off'/'#verb='/'#verb=none' (clear)."""
+        say_settings = ctx.player.command_settings.say
+
+        if switch == '#verb':
+            if say_settings.verb:
+                third = _third_person(say_settings.verb)
+                await ctx.send(f'Your say verb is "{say_settings.verb}" -- '
+                                f'{ctx.player.name} {third}, "..."')
+            else:
+                await ctx.send('No custom say verb set -- the verb follows your '
+                                "trailing punctuation (says/asks/exclaims/mutters). "
+                                "Set one with 'say #verb=<word>'.")
+            return CommandResult.ok()
+
+        value = switch[len('#verb='):].strip()
+        if value in ('', 'off', 'none'):
+            say_settings.verb = None
+            await ctx.send('Say verb cleared -- back to punctuation-based '
+                            '(says/asks/exclaims/mutters).')
+            return CommandResult.ok()
+
+        say_settings.verb = value
+        third = _third_person(value)
+        await ctx.send(f'Say verb set to "{value}" -- '
+                        f'{ctx.player.name} {third}, "..."')
         return CommandResult.ok()

--- a/server/commands/say.py
+++ b/server/commands/say.py
@@ -25,6 +25,10 @@ that line (doesn't touch command_settings.say.verb):
   →  Rulan grumbles, "Hello"
 'say #verb=off' (or '#verb='/'#verb=none') clears it. Bare 'say #verb'
 previews the current verb without broadcasting anything.
+
+'say #split' is the inline equivalent of PREFS 'Y': bare 'say #split'
+reports the current on/off state, 'say #split on'/'say #split off' sets
+it explicitly, and 'say #unsplit' is shorthand for 'say #split off'.
 """
 from commands.base_command import Command, CommandResult, Mode
 from commands.help import Help, HelpCategory
@@ -42,6 +46,9 @@ _VERB_MAP = [
     ('...', ('mutters',  'mutter')),
 ]
 _DEFAULT_VERB = ('says', 'say')
+
+_TRUTHY = {'on', 'true', '1', 'yes'}
+_FALSY  = {'off', 'false', '0', 'no'}
 
 
 def _choose_verb(text: str):
@@ -115,6 +122,8 @@ class SayCommand(Command):
             ('say #verb=<word>',     'Always use <word> as your say verb'),
             ('say #verb',            'Preview your current say verb'),
             ('say #verb=off',        'Clear the custom verb'),
+            ('say #split [on|off]',  "Report, or set, Say Split (same as PREFS 'Y')"),
+            ('say #unsplit',         "Shorthand for 'say #split off'"),
         ],
         examples = [
             ('say Hello there!',   'SAY broadcasts a message to everyone in your room, '
@@ -143,6 +152,12 @@ class SayCommand(Command):
                                     'verb without saying anything (or tells you none '
                                     "is set). 'say #verb=off' clears it, back to "
                                     'punctuation-based selection.'),
+            ('say #split',          "Inline equivalent of PREFS 'Y' -- bare "
+                                    "'say #split' reports Say split is On. or "
+                                    "Say split is Off. without saying anything; "
+                                    "'say #split on'/'say #split off' sets it "
+                                    "directly, and 'say #unsplit' is shorthand "
+                                    "for 'say #split off'."),
         ],
         notes = [
             "Say Split (PREFS 'Y') must be on for ',,' and ',,,' to do "
@@ -157,6 +172,11 @@ class SayCommand(Command):
         verb_switch = next((s for s in switches if s == '#verb' or s.startswith('#verb=')), None)
         if verb_switch is not None:
             return await self._handle_verb_switch(ctx, verb_switch)
+
+        if '#split' in switches:
+            return await self._handle_split_switch(ctx, args)
+        if '#unsplit' in switches:
+            return await self._handle_split_switch(ctx, ['off'])
 
         # Reconstruct the message; strip a leading " if the shortcut was used
         text = ' '.join(args).lstrip('"').strip()
@@ -218,4 +238,22 @@ class SayCommand(Command):
         third = _third_person(value)
         await ctx.send(f'Say verb set to "{value}" -- '
                         f'{ctx.player.name} {third}, "..."')
+        return CommandResult.ok()
+
+    async def _handle_split_switch(self, ctx: GameContext, args: list) -> CommandResult:
+        """'say #split' (bare: preview; with on/off: set) and
+        'say #unsplit' (routed here with a synthetic 'off' arg)."""
+        say_settings = ctx.player.command_settings.say
+
+        if args:
+            value = args[0].lower()
+            if value in _TRUTHY:
+                say_settings.split = True
+            elif value in _FALSY:
+                say_settings.split = False
+            else:
+                await ctx.send(f"Say split unchanged -- \"{args[0]}\" isn't on/off.")
+                return CommandResult.ok()
+
+        await ctx.send(f"Say split is {'On' if say_settings.split else 'Off'}.")
         return CommandResult.ok()

--- a/server/commands/say.py
+++ b/server/commands/say.py
@@ -105,12 +105,12 @@ class SayCommand(Command):
             "The verb changes based on punctuation: "
             "? = asks, ! = exclaims, ... = mutters, otherwise says. "
             'The " shortcut works without typing "say" first. '
+            "With Say Split turned on in PREFS ('Y'), a ',,' in your "
+            "message splits it into a mid-sentence attribution, and a "
+            "',,,' attaches a one-off verb right after the quote instead.\n\n"
             "'say #verb=<word>' sets a permanent custom verb instead, "
             "overriding punctuation entirely -- 'say #verb' previews it, "
-            "'say #verb=off' clears it. With Say Split turned on in PREFS "
-            "('Y'), a ',,' in your message splits it into a mid-sentence "
-            "attribution, and a ',,,' attaches a one-off verb right after "
-            "the quote instead."
+            "'say #verb=off' clears it."
         ),
         category = HelpCategory.COMMUNICATION,
         usage    = [

--- a/server/commands/say.py
+++ b/server/commands/say.py
@@ -104,13 +104,7 @@ class SayCommand(Command):
             "Broadcasts a message to all players in your room. "
             "The verb changes based on punctuation: "
             "? = asks, ! = exclaims, ... = mutters, otherwise says. "
-            'The " shortcut works without typing "say" first. '
-            "With Say Split turned on in PREFS ('Y'), a ',,' in your "
-            "message splits it into a mid-sentence attribution, and a "
-            "',,,' attaches a one-off verb right after the quote instead.\n\n"
-            "'say #verb=<word>' sets a permanent custom verb instead, "
-            "overriding punctuation entirely -- 'say #verb' previews it, "
-            "'say #verb=off' clears it."
+            'The " shortcut works without typing "say" first.'
         ),
         category = HelpCategory.COMMUNICATION,
         usage    = [
@@ -144,10 +138,11 @@ class SayCommand(Command):
                                     "touching your saved #verb."),
             ('say #verb=grumble',   "Sets your say verb permanently -- afterward, "
                                     '"say Hello" shows as Rulan grumbles, "Hello", '
-                                    'overriding the punctuation-based verb entirely. '
-                                    "'say #verb' alone previews the current verb "
-                                    "without saying anything, and 'say #verb=off' "
-                                    'clears it.'),
+                                    'overriding the punctuation-based verb entirely.'),
+            ('say #verb',           "Bare 'say #verb' previews your current custom "
+                                    'verb without saying anything (or tells you none '
+                                    "is set). 'say #verb=off' clears it, back to "
+                                    'punctuation-based selection.'),
         ],
         notes = [
             "Say Split (PREFS 'Y') must be on for ',,' and ',,,' to do "


### PR DESCRIPTION
## Summary
- `say #verb=<word>` sets a persistent custom verb overriding punctuation-based selection (e.g. `say #verb=grumble` + `say Hello` → `Rulan grumbles, "Hello"`); bare `say #verb` previews the current verb, `say #verb=off` clears it.
- `say #split [on|off]` toggles "Say Split" (also available as PREFS option Y): when on, a `,,` in the message splits it into a mid-sentence attribution (`This is something,,up with which I will not put!` → `"This is something," Rulan exclaims, "up with which I will not put!"`), and `,,,` attaches a one-off verb right after the quote (`Argh!,,,moan` → `"Argh!" moans Rulan.`). Bare `say #split` reports current status; `say #unsplit` is shorthand for off.
- `CommandSettings.say` (new `SaySettings` dataclass: `split`, `verb`) persists both preferences per-player.
- Updated `help say` with new usage/examples entries per switch, matching the existing per-switch tuple convention (see `tips.py`).

## Testing
Verified live against the running dev server (hot-reload + reconnect cycle for each `CommandSettings`/`CommandProcessor` change):
- `say #verb=grumble` then `say Hello` → `Rulan grumbles, "Hello"`; bare `say #verb` and `say #verb=off` both behave as documented.
- `say #split` on/off toggling, `,,` and `,,,` comma forms, `say #unsplit`.
- `help say` renders correctly with the new usage/examples entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)