### PR TITLE
READY/UNREADY: let the player ready & unready allies' weapons

### DIFF
--- a/server/bar/ally_data.py
+++ b/server/bar/ally_data.py
@@ -112,7 +112,9 @@ class Ally:
         self.items: list = []   # items given by player via GIVE (persisted, see party.py)
         # Weapon combat (TADA-only extension -- SPUR allies never carry a
         # weapons.json entry, see combat/resolution.py ally_attacks()).
-        # Auto-readied by commands/give.py when the player GIVEs a Weapon.
+        # A GIVEn weapon lands in self.items; the player chooses when the
+        # ally actually wields it via READY (commands/ready.py's
+        # _toggle_ally_weapon) -- alpha testers disliked auto-readying.
         self.readied_weapon = None       # items.Weapon or None
         self.ammo_rounds: int = 0        # rounds currently loaded
         self.ammo_max:    int = 0        # capacity, for recovery/display

--- a/server/commands/give.py
+++ b/server/commands/give.py
@@ -412,9 +412,13 @@ class GiveCommand(Command):
                     await ctx.send(f"{ally.name}'s saddlebags are full.")
                     return CommandResult.ok()
 
-            # Weapon: allies have no READY command of their own, so a given
-            # weapon is auto-readied on the spot (replacing whatever they
-            # had -- combat/resolution.py ally_attacks() reads ally.readied_weapon).
+            # Weapon: the ally just stows it -- alpha testers found it
+            # nonsensical for an ally to auto-ready a weapon the instant it
+            # changed hands (they might already be wielding something they
+            # prefer, or the player may be handing over a spare). The
+            # player now decides who wields what, and when, via READY,
+            # which lists allies' carried weapons (commands/ready.py's
+            # _ally_weapon_entries / _toggle_ally_weapon).
             from items import Weapon
             from bar.ally_data import add_ally_item
             if isinstance(item, Weapon):
@@ -431,10 +435,6 @@ class GiveCommand(Command):
                 unworn_slot = unworn_if_given_away(player, item)
                 if inventory:
                     inventory.remove(item)
-                ally.readied_weapon = item
-                ally.ammo_rounds = 0
-                ally.ammo_max = 0
-                ally.ammo_damage = 0
                 # add_ally_item(), not a raw ally.items.append(entry) --
                 # (a) it stacks onto a matching existing entry instead of
                 # always appending a duplicate (a given ally rarely holds
@@ -458,9 +458,11 @@ class GiveCommand(Command):
                     notice = unworn_notice(unworn_slot, iname)
                     if notice:
                         await ctx.send(notice)
-                await ctx.send(f'{ally.name} readies the {iname}!')
+                await ctx.send(f'{ally.name} stows the {iname}.')
+                if not player.is_expert:
+                    await ctx.send(f'(READY it to have {ally.name} wield it.)')
                 await ctx.send_room(
-                    f'{pself} gives the {iname} to {ally.name}, who readies it!',
+                    f'{pself} gives the {iname} to {ally.name}.',
                     exclude_self=True)
                 return CommandResult.ok()
 
@@ -480,6 +482,8 @@ class GiveCommand(Command):
                 weapon = getattr(ally, 'readied_weapon', None)
                 if weapon is None:
                     await ctx.send(f'{ally.name} has no weapon readied to load {iname} into.')
+                    if not player.is_expert:
+                        await ctx.send(f'(READY a weapon for {ally.name} first.)')
                     return CommandResult.ok()
                 wname_upper = (getattr(weapon, 'name', '') or '').upper()
                 reason = ammo_load_error(weapon, flags)

--- a/server/commands/ready.py
+++ b/server/commands/ready.py
@@ -70,6 +70,77 @@ def _stat(player, key) -> int:
     return int(stats.get(key, 0) or 0)
 
 
+def _party_allies(player):
+    """Living party allies, in party order.
+
+    Alpha-tester feedback: it made no sense for an ally to *automatically*
+    ready a weapon the moment it was GIVEn to them (commands/give.py used
+    to do exactly that). READY now also lists every weapon sitting in an
+    ally's pack (bar/ally_data.py Ally.items) so the player decides who
+    wields what, and when -- see _ally_weapon_entries() below.
+    """
+    party = getattr(player, 'party', None)
+    if not party:
+        return []
+    try:
+        from bar.ally_data import Ally, AllyStatus
+    except ImportError:
+        return []
+    out = []
+    for m in getattr(party, 'members', None) or []:
+        if not isinstance(m, Ally):
+            continue
+        if getattr(m, 'status', None) == AllyStatus.DEAD:
+            continue
+        out.append(m)
+    return out
+
+
+def _ally_weapon_entries(player):
+    """[(ally, InventoryEntry)] for every weapon in each party ally's pack."""
+    result = []
+    for ally in _party_allies(player):
+        for entry in getattr(ally, 'items', None) or []:
+            item = getattr(entry, 'item', None)
+            if item is None:
+                continue
+            if str(getattr(item, 'category', '')) == str(ItemCategory.WEAPON):
+                result.append((ally, entry))
+    return result
+
+
+def _ally_has_readied(ally, item) -> bool:
+    """True if *item* is the weapon *ally* currently has readied."""
+    cur = getattr(ally, 'readied_weapon', None)
+    if cur is None:
+        return False
+    if cur is item:
+        return True
+    cur_id, item_id = getattr(cur, 'id_number', None), getattr(item, 'id_number', None)
+    return cur_id is not None and cur_id == item_id
+
+
+async def _toggle_ally_weapon(ctx, player, ally, item) -> CommandResult:
+    """Ready *item* for *ally*, or unready it if it's already their readied
+    weapon. Ammo counters reset either way (commands/give.py's ammo load-in
+    is keyed to whatever weapon is readied *now*)."""
+    name  = getattr(item, 'name', '?')
+    pself = getattr(player, 'name', 'Someone')
+    ally.ammo_rounds = ally.ammo_max = ally.ammo_damage = 0
+    player.unsaved_changes = True
+    if _ally_has_readied(ally, item):
+        ally.readied_weapon = None
+        await ctx.send(f'{ally.name} repacks the {name}.')
+        await ctx.send_room(f'{pself} has {ally.name} repack the {name}.',
+                            exclude_self=True)
+    else:
+        ally.readied_weapon = item
+        await ctx.send(f'{ally.name} readies the {name}!')
+        await ctx.send_room(f'{pself} has {ally.name} ready the {name}!',
+                            exclude_self=True)
+    return CommandResult.ok()
+
+
 def _weapon_class_line(weapon) -> list[str]:
     """Build the 'Weapon class: X' line(s) shown when readying.
 
@@ -109,17 +180,22 @@ class ReadyCommand(Command):
         summary  = 'Ready a weapon from your inventory.',
         category = HelpCategory.GENERAL,
         usage    = [
-            ('ready',         'List carried weapons and choose one'),
-            ('ready <name>',  'Ready the weapon matching name'),
+            ('ready',          'List weapons (yours and your allies\') and choose one'),
+            ('ready <name>',   'Ready the weapon (or ally) matching name'),
         ],
         examples = [
             ('ready',         "READY wields a weapon from your inventory, showing its "
                                "class, ease of use, and damage once equipped. With no "
                                "name given, it lists everything you're carrying that can "
-                               "be readied and lets you pick one."),
+                               "be readied -- plus any weapons your allies are carrying "
+                               "-- and lets you pick one."),
             ('ready sword',   'Naming a weapon (a partial match works) readies it '
                                'directly -- "ready sword" wields whatever you\'re '
                                'carrying with "sword" in its name.'),
+            ('ready alan',    "Allies don't ready GIVEn weapons on their own. Pick an "
+                               "ally's weapon from the READY list (or name the ally / "
+                               "the weapon) to have them wield it; pick it again to "
+                               "have them repack it."),
         ],
         see_also = ['combat', 'weaponclass', 'basedamage', 'easeofuse', 'weaponaffinity'],
     )
@@ -128,67 +204,109 @@ class ReadyCommand(Command):
         args, _switches = self.parse_args(*args)
         player  = ctx.player
         entries = _weapon_entries(player)
+        ally_entries = _ally_weapon_entries(player)   # [(ally, InventoryEntry)]
 
-        if not entries:
+        if not entries and not ally_entries:
             await ctx.send('You have no weapons to ready.')
             return CommandResult.ok()
 
-        str_val = _stat(player, PlayerStat.STR)
-        if str_val < _MIN_STR:
+        # STR gates the player's own arm, not an ally's -- only short-circuit
+        # here when there's nothing but the player's own weapons to offer
+        # (an ally weapon is still readiable below regardless of the
+        # player's Strength).
+        if not ally_entries and _stat(player, PlayerStat.STR) < _MIN_STR:
             await ctx.send('Not enough strength to ready a weapon!')
             return CommandResult.ok()
 
-        # Resolve target entry: by name arg or interactive prompt
+        def _ally_label(ally, e) -> str:
+            wname = getattr(e.item, 'name', '?')
+            tag   = '  (readied)' if _ally_has_readied(ally, e.item) else ''
+            return f'{ally.name}: {wname}{tag}'
+
+        # Resolve the target: one of the player's own weapon entries, or an
+        # (ally, entry) pair. Picking an ally's weapon toggles that ally's
+        # readied weapon and returns straight away -- the player-side
+        # readying flow below only runs for the player's own weapons.
         if args:
             pattern = ' '.join(args).lower()
-            matches = [(i, e) for i, e in enumerate(entries)
-                       if pattern in (getattr(e.item, 'name', '') or '').lower()]
-            if not matches:
-                await ctx.send(f'You are not carrying any weapon matching "{" ".join(args)}".')
+            p_matches = [e for e in entries
+                         if pattern in (getattr(e.item, 'name', '') or '').lower()]
+            a_matches = [(ally, e) for (ally, e) in ally_entries
+                         if pattern in (getattr(e.item, 'name', '') or '').lower()
+                         or pattern in ally.name.lower()]
+            combined = [('p', e) for e in p_matches] + [('a', pair) for pair in a_matches]
+            if not combined:
+                await ctx.send(f'No weapon or ally matching "{" ".join(args)}".')
                 return CommandResult.ok()
-            if len(matches) == 1:
-                entry = matches[0][1]
+            if len(combined) == 1:
+                kind, obj = combined[0]
+                if kind == 'a':
+                    return await _toggle_ally_weapon(ctx, player, obj[0], obj[1].item)
+                entry = obj
             else:
                 lines = ['Which weapon?', '']
-                for _, (orig_i, e) in enumerate(matches, 1):
-                    lines.append(f'  {orig_i + 1:>2}. {getattr(e.item, "name", "?")}')
+                for n, (kind, obj) in enumerate(combined, 1):
+                    if kind == 'p':
+                        lines.append(f'  {n:>2}. {getattr(obj.item, "name", "?")}')
+                    else:
+                        lines.append(f'  {n:>2}. {_ally_label(obj[0], obj[1])}')
                 lines.append('')
                 await ctx.send(lines)
-                raw = await ctx.prompt(preamble_lines=f'(1-{len(matches)}, {ctx.player.return_key} to cancel)',
+                raw = await ctx.prompt(preamble_lines=f'(1-{len(combined)}, {ctx.player.return_key} to cancel)',
                                        prompt_text="Ready which")
                 if not raw or not raw.strip():
                     return CommandResult.ok()
                 try:
                     pick = int(raw.strip()) - 1
-                    if not (0 <= pick < len(matches)):
+                    if not (0 <= pick < len(combined)):
                         raise ValueError
                 except ValueError:
                     await ctx.send('Invalid selection.')
                     return CommandResult.ok()
-                entry = matches[pick][1]
+                kind, obj = combined[pick]
+                if kind == 'a':
+                    return await _toggle_ally_weapon(ctx, player, obj[0], obj[1].item)
+                entry = obj
         else:
-            lines = ['Weapons you carry:', '']
-            for i, e in enumerate(entries, 1):
-                name    = getattr(e.item, 'name', '?')
-                wc      = getattr(e.item, 'weapon_class', None)
-                wc_str  = (wc.value if hasattr(wc, 'value') else str(wc)) if wc else ''
-                vp      = _battle_exp(player, e.item)
-                badge   = _tier_label(vp)
-                lines.append(f'  {i:>2}. {name:<22} {wc_str:<18} {badge}')
-            lines.append('')
+            lines = []
+            if entries:
+                lines += ['Weapons you carry:', '']
+                for i, e in enumerate(entries, 1):
+                    name    = getattr(e.item, 'name', '?')
+                    wc      = getattr(e.item, 'weapon_class', None)
+                    wc_str  = (wc.value if hasattr(wc, 'value') else str(wc)) if wc else ''
+                    vp      = _battle_exp(player, e.item)
+                    badge   = _tier_label(vp)
+                    lines.append(f'  {i:>2}. {name:<22} {wc_str:<18} {badge}')
+                lines.append('')
+            if ally_entries:
+                lines += ["Your allies' weapons:", '']
+                for j, (ally, e) in enumerate(ally_entries, len(entries) + 1):
+                    lines.append(f'  {j:>2}. {_ally_label(ally, e)}')
+                lines.append('')
+            total = len(entries) + len(ally_entries)
             await ctx.send(lines)
-            raw = await ctx.prompt(preamble_lines=f'(1-{len(entries)}, {ctx.player.return_key} to cancel)',
+            raw = await ctx.prompt(preamble_lines=f'(1-{total}, {ctx.player.return_key} to cancel)',
                                    prompt_text="Ready which weapon")
             if not raw or not raw.strip():
                 return CommandResult.ok()
             try:
                 choice = int(raw.strip()) - 1
-                if not (0 <= choice < len(entries)):
+                if not (0 <= choice < total):
                     raise ValueError
             except ValueError:
                 await ctx.send('Invalid selection.')
                 return CommandResult.ok()
+            if choice >= len(entries):
+                ally, e = ally_entries[choice - len(entries)]
+                return await _toggle_ally_weapon(ctx, player, ally, e.item)
             entry = entries[choice]
+
+        # From here on the player is readying one of their *own* weapons.
+        str_val = _stat(player, PlayerStat.STR)
+        if str_val < _MIN_STR:
+            await ctx.send('Not enough strength to ready a weapon!')
+            return CommandResult.ok()
 
         weapon = entry.item
         name   = getattr(weapon, 'name', '?')

--- a/server/commands/stats.py
+++ b/server/commands/stats.py
@@ -356,8 +356,8 @@ def _build_stats_lines(player, ctx=None) -> list[str]:
     # table.py Table (Ally/Str/HP/Hit%/Notes columns) per Ryan's request;
     # Notes carries every AllyFlags member (see _ally_flag_tags), any
     # non-default AllyStatus tag, a Wpn tag for the ally's readied weapon
-    # (see _ally_weapon_display -- commands/give.py auto-readies a Weapon
-    # on GIVE), and a Worn tag for readied_armor/readied_shield (see
+    # (see _ally_weapon_display -- set via READY, commands/ready.py's
+    # _toggle_ally_weapon), and a Worn tag for readied_armor/readied_shield (see
     # _ally_worn_display -- commands/give.py auto-wears an armor/shield
     # Item the same way, added 2026-08-09). Not its own fixed-width table
     # column -- that starved Notes' width on narrow/C64 screens when tried

--- a/server/commands/unready.py
+++ b/server/commands/unready.py
@@ -19,17 +19,59 @@ class UnreadyCommand(Command):
     modes   = {Mode.GAME}
 
     help = Help(
-        summary  = 'Unready your currently readied weapon.',
+        summary  = "Unready your (or an ally's) readied weapon.",
         category = HelpCategory.GENERAL,
-        usage    = [('unready', 'Repack your readied weapon.')],
-        examples = [('unready', "UNREADY (also 'unwield') takes no arguments -- it just "
-                                 "repacks whatever weapon you currently have readied, "
-                                 "leaving you unarmed. Fails harmlessly with \"No weapon "
-                                 "readied!\" if you weren't wielding anything.")],
+        usage    = [
+            ('unready',        'Repack your readied weapon.'),
+            ('unready <ally>', 'Have a party ally repack their readied weapon.'),
+        ],
+        examples = [('unready', "UNREADY (also 'unwield') with no argument repacks "
+                                 "whatever weapon you currently have readied, leaving "
+                                 "you unarmed. Fails harmlessly with \"No weapon "
+                                 "readied!\" if you weren't wielding anything. Name a "
+                                 "party ally (\"unready alan\") to have them repack "
+                                 "theirs instead -- the same toggle READY offers.")],
     )
 
     async def execute(self, ctx: GameContext, *args) -> CommandResult:
         player = ctx.player
+        args, _switches = self.parse_args(*args)
+
+        # "unready <ally>" -- repack a party ally's readied weapon, the
+        # mirror of READY's ally-weapon toggle (commands/ready.py). Allies
+        # no longer auto-ready GIVEn weapons, so the player drives both
+        # ends of it.
+        if args:
+            target = ' '.join(args).lower()
+            try:
+                from bar.ally_data import Ally, AllyStatus
+            except ImportError:
+                Ally = None
+            party = getattr(player, 'party', None)
+            members = (getattr(party, 'members', None) or []) if party else []
+            for m in members:
+                if Ally is not None and not isinstance(m, Ally):
+                    continue
+                if getattr(m, 'status', None) == getattr(AllyStatus, 'DEAD', None):
+                    continue
+                if target not in getattr(m, 'name', '').lower():
+                    continue
+                a_weapon = getattr(m, 'readied_weapon', None)
+                if a_weapon is None:
+                    await ctx.send(f'{m.name} has no weapon readied.')
+                    return CommandResult.ok()
+                aname = getattr(a_weapon, 'name', '?')
+                m.readied_weapon = None
+                m.ammo_rounds = m.ammo_max = m.ammo_damage = 0
+                player.unsaved_changes = True
+                pself = getattr(player, 'name', 'Someone')
+                await ctx.send(f'{m.name} repacks the {aname}.')
+                await ctx.send_room(f'{pself} has {m.name} repack the {aname}.',
+                                    exclude_self=True)
+                return CommandResult.ok()
+            await ctx.send(f'No party ally matching "{" ".join(args)}".')
+            return CommandResult.ok()
+
         weapon = getattr(player, 'readied_weapon', None)
 
         if weapon is None:

--- a/server/tests/combat/test_ready.py
+++ b/server/tests/combat/test_ready.py
@@ -76,6 +76,9 @@ class _FakeCtx:
     async def prompt(self, *a, **kw):
         return next(self._answers, None)
 
+    async def send_room(self, msg, **kwargs):
+        pass
+
     def sent(self) -> str:
         return '\n'.join(self._sent)
 
@@ -285,6 +288,105 @@ class TestWeaponAffinityTip(unittest.IsolatedAsyncioTestCase):
         ctx = _FakeCtx(player)
         await ReadyCommand().execute(ctx, 'sword')
         self.assertNotIn('[HELP WEAPON AFFINITY]', ctx.sent())
+
+
+class TestReadyAllyWeapons(unittest.IsolatedAsyncioTestCase):
+    """Alpha-tester feedback: allies no longer auto-ready a GIVEn weapon.
+    READY now lists each party ally's carried weapons and toggles
+    ally.readied_weapon on selection (commands/ready.py's
+    _ally_weapon_entries / _toggle_ally_weapon)."""
+
+    def _party_with_ally(self, player, weapons):
+        from bar.ally_data import Ally, AllyStatus, add_ally_item
+        from party import Party
+        ally = Ally('ALAN OF YOR', 'm', 12, 5)
+        ally.status = AllyStatus.SERVANT
+        for w in weapons:
+            add_ally_item(ally, w, quantity=1)
+        player.name = 'Rulan'
+        player.return_key = 'RETURN'
+        player.party = Party()
+        player.party.add_member(player, ally)
+        return ally
+
+    async def test_bare_ready_lists_ally_weapons(self):
+        player = _FakePlayer(weapons=[])
+        self._party_with_ally(player, [_weapon('SHORT SWORD', item_id=3)])
+        ctx = _FakeCtx(player)
+        ctx.set_answers([''])   # cancel at the prompt
+        await ReadyCommand().execute(ctx)
+        self.assertIn("Your allies' weapons:", ctx.sent())
+        self.assertIn('ALAN OF YOR: SHORT SWORD', ctx.sent())
+
+    async def test_pick_ally_weapon_readies_it(self):
+        player = _FakePlayer(weapons=[])
+        sword = _weapon('SHORT SWORD', item_id=3)
+        ally = self._party_with_ally(player, [sword])
+        ctx = _FakeCtx(player)
+        ctx.set_answers(['1'])   # only entry in the list
+        await ReadyCommand().execute(ctx)
+        self.assertIs(ally.readied_weapon, sword)
+        self.assertIn('ALAN OF YOR readies the SHORT SWORD', ctx.sent())
+        self.assertTrue(player.unsaved_changes)
+
+    async def test_pick_readied_ally_weapon_again_unreadies_it(self):
+        player = _FakePlayer(weapons=[])
+        sword = _weapon('SHORT SWORD', item_id=3)
+        ally = self._party_with_ally(player, [sword])
+        ally.readied_weapon = sword
+        ctx = _FakeCtx(player)
+        ctx.set_answers(['1'])
+        await ReadyCommand().execute(ctx)
+        self.assertIsNone(ally.readied_weapon)
+        self.assertIn('ALAN OF YOR repacks the SHORT SWORD', ctx.sent())
+
+    async def test_ready_by_ally_name_toggles(self):
+        player = _FakePlayer(weapons=[])
+        sword = _weapon('SHORT SWORD', item_id=3)
+        ally = self._party_with_ally(player, [sword])
+        ctx = _FakeCtx(player)
+        await ReadyCommand().execute(ctx, 'alan')
+        self.assertIs(ally.readied_weapon, sword)
+
+    async def test_ready_by_weapon_name_targets_ally_weapon(self):
+        player = _FakePlayer(weapons=[])
+        sword = _weapon('SHORT SWORD', item_id=3)
+        ally = self._party_with_ally(player, [sword])
+        ctx = _FakeCtx(player)
+        await ReadyCommand().execute(ctx, 'short', 'sword')
+        self.assertIs(ally.readied_weapon, sword)
+
+    async def test_readied_ally_weapon_shows_tag_in_list(self):
+        player = _FakePlayer(weapons=[])
+        sword = _weapon('SHORT SWORD', item_id=3)
+        ally = self._party_with_ally(player, [sword])
+        ally.readied_weapon = sword
+        ctx = _FakeCtx(player)
+        ctx.set_answers([''])
+        await ReadyCommand().execute(ctx)
+        self.assertIn('SHORT SWORD  (readied)', ctx.sent())
+
+    async def test_low_strength_still_allows_readying_ally_weapon(self):
+        # The STR gate is about the player's own arm -- it must not block
+        # directing an ally to wield theirs.
+        player = _FakePlayer(str_stat=1, weapons=[])
+        sword = _weapon('SHORT SWORD', item_id=3)
+        ally = self._party_with_ally(player, [sword])
+        ctx = _FakeCtx(player)
+        await ReadyCommand().execute(ctx, 'alan')
+        self.assertIs(ally.readied_weapon, sword)
+        self.assertNotIn('strength', ctx.sent().lower())
+
+    async def test_player_and_ally_weapons_numbered_together(self):
+        my_sword = _weapon('LONG SWORD', item_id=2)
+        player = _FakePlayer(weapons=[my_sword])
+        ally_bow = _weapon('LONG BOW', item_id=4)
+        ally = self._party_with_ally(player, [ally_bow])
+        ctx = _FakeCtx(player)
+        ctx.set_answers(['2'])   # 1 = own LONG SWORD, 2 = ally's LONG BOW
+        await ReadyCommand().execute(ctx)
+        self.assertIs(ally.readied_weapon, ally_bow)
+        self.assertIsNone(player.readied_weapon)
 
 
 if __name__ == '__main__':

--- a/server/tests/combat/test_unready.py
+++ b/server/tests/combat/test_unready.py
@@ -35,6 +35,9 @@ class _FakeCtx:
         else:
             self._sent.append(str(msg))
 
+    async def send_room(self, msg, **kwargs):
+        pass
+
     def sent(self) -> str:
         return '\n'.join(self._sent)
 
@@ -64,6 +67,45 @@ class TestUnreadyCommand(unittest.IsolatedAsyncioTestCase):
         ctx = _FakeCtx(player)
         await UnreadyCommand().execute(ctx)
         self.assertIsNone(player.storm_servant_bonus)
+
+
+class TestUnreadyAllyWeapon(unittest.IsolatedAsyncioTestCase):
+    """"unready <ally>" -- mirror of READY's ally-weapon toggle."""
+
+    def _player_with_ally(self, readied=None):
+        from bar.ally_data import Ally, AllyStatus
+        from party import Party
+        player = _FakePlayer(readied_weapon=None)
+        player.name = 'Rulan'
+        ally = Ally('ALAN OF YOR', 'm', 12, 5)
+        ally.status = AllyStatus.SERVANT
+        ally.readied_weapon = readied
+        player.party = Party()
+        player.party.add_member(player, ally)
+        return player, ally
+
+    async def test_unready_named_ally_repacks_their_weapon(self):
+        player, ally = self._player_with_ally(readied=_FakeWeapon('SHORT SWORD'))
+        ally.ammo_rounds = 5
+        ctx = _FakeCtx(player)
+        await UnreadyCommand().execute(ctx, 'alan')
+        self.assertIsNone(ally.readied_weapon)
+        self.assertEqual(ally.ammo_rounds, 0)
+        self.assertIn('ALAN OF YOR repacks the SHORT SWORD.', ctx.sent())
+        self.assertTrue(player.unsaved_changes)
+
+    async def test_unready_ally_with_nothing_readied(self):
+        player, ally = self._player_with_ally(readied=None)
+        ctx = _FakeCtx(player)
+        await UnreadyCommand().execute(ctx, 'alan')
+        self.assertIn('ALAN OF YOR has no weapon readied.', ctx.sent())
+
+    async def test_unready_unknown_ally_name(self):
+        player, ally = self._player_with_ally(readied=_FakeWeapon('SHORT SWORD'))
+        ctx = _FakeCtx(player)
+        await UnreadyCommand().execute(ctx, 'nobody')
+        self.assertIn('No party ally matching "nobody".', ctx.sent())
+        self.assertIsNotNone(ally.readied_weapon)
 
 
 if __name__ == '__main__':

--- a/server/tests/commands/test_give_take.py
+++ b/server/tests/commands/test_give_take.py
@@ -339,21 +339,22 @@ class TestGiveToAlly(unittest.IsolatedAsyncioTestCase):
 
 
 # ---------------------------------------------------------------------------
-# GiveCommand — weapon auto-ready + ammo load-in for allies
+# GiveCommand — weapon stow + ammo load-in for allies
 #
-# Regression coverage for the bug fixed 2026-08-01: GiveCommand's
-# weapon-auto-ready branch checked `isinstance(item, Weapon)` against
-# item_system.Weapon, a class nothing in production code ever
-# constructs -- every real weapon (armory purchases, items.resolve_weapon()
-# reconstruction) is an items.Weapon instead, so the isinstance check was
-# always False. A GIVEn weapon silently fell through to the generic "takes
-# it and tucks it away" branch, ally.readied_weapon was never set, and a
-# follow-up GIVE of matching ammo always hit "has no weapon readied" even
-# though the player had just handed over the weapon. Fixed by importing
-# the real items.Weapon. This test drives GiveCommand end-to-end with a
-# real items.Weapon (built the way shoppe/armory.py builds one) rather
-# than hand-assigning ally.readied_weapon, so a regression of the
-# wrong-class import trips this test again.
+# Alpha-tester feedback (2026-09-01): a GIVEn weapon used to be
+# auto-readied on the ally the instant it changed hands, which testers
+# found nonsensical (the ally might already be wielding something better,
+# or the weapon may be a spare). A GIVEn weapon now just lands in
+# ally.items; the player readies it deliberately via READY (see
+# commands/ready.py's _ally_weapon_entries / _toggle_ally_weapon and
+# tests/combat/test_ready.py). Ammo still loads only into a *readied*
+# weapon, so these tests READY the stowed weapon first.
+#
+# (The 2026-08-01 bug this section originally covered -- GiveCommand's
+# `isinstance(item, Weapon)` checked the wrong Weapon class, so weapons
+# fell through to the generic "tucks it away" branch -- is still guarded:
+# a real items.Weapon must reach the dedicated stow branch, land in
+# ally.items, and leave the player's inventory.)
 # ---------------------------------------------------------------------------
 
 def _make_weapon(name: str = '.357 MAGNUM', item_id: int = 145) -> Weapon:
@@ -375,21 +376,29 @@ class TestGiveWeaponAndAmmoToAlly(unittest.IsolatedAsyncioTestCase):
         self.player.party.add_member(self.player, self.ally)
         self.ctx = _FakeCtx(self.player)
 
-    async def test_give_weapon_to_ally_readies_it(self):
+    async def test_give_weapon_to_ally_stows_it(self):
         weapon = _make_weapon()
         self.player.inventory.add(weapon)
         await self.cmd.execute(self.ctx, '.357', 'magnum', 'to', 'morganna')
 
-        self.assertIs(self.ally.readied_weapon, weapon)
-        self.assertIn('READIES', self.ctx.sent().upper())
+        # No longer auto-readied -- it just lands in the ally's pack.
+        self.assertIsNone(self.ally.readied_weapon)
+        self.assertEqual(len(self.ally.items), 1)
+        self.assertIs(self.ally.items[0].item, weapon)
+        self.assertIn('STOWS', self.ctx.sent().upper())
+        self.assertNotIn('READIES', self.ctx.sent().upper())
         self.assertEqual(len(self.player.inventory.entries()), 0)
         # See TestGiveToAlly.test_give_item_to_ally_marks_player_unsaved.
         self.assertTrue(self.player.unsaved_changes)
 
-    async def test_give_matching_ammo_after_weapon_loads_it(self):
+    async def test_give_matching_ammo_after_readying_weapon_loads_it(self):
+        from commands.ready import ReadyCommand
         weapon = _make_weapon()
         self.player.inventory.add(weapon)
         await self.cmd.execute(self.ctx, '.357', 'magnum', 'to', 'morganna')
+        # Player readies it for the ally -- allies no longer do this themselves.
+        await ReadyCommand().execute(self.ctx, '.357')
+        self.assertIs(self.ally.readied_weapon, weapon)
 
         ammo = _make_ammo()
         self.player.inventory.add(ammo)
@@ -400,6 +409,19 @@ class TestGiveWeaponAndAmmoToAlly(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(self.ally.ammo_damage, 4)
         self.assertIn('LOADS', self.ctx.sent().upper())
         self.assertTrue(self.player.unsaved_changes)
+
+    async def test_give_ammo_before_readying_weapon_is_rejected(self):
+        # Weapon in the ally's pack but not readied -> ammo has nowhere to go.
+        weapon = _make_weapon()
+        self.player.inventory.add(weapon)
+        await self.cmd.execute(self.ctx, '.357', 'magnum', 'to', 'morganna')
+
+        ammo = _make_ammo()
+        self.player.inventory.add(ammo)
+        await self.cmd.execute(self.ctx, '.357', 'ammo', 'to', 'morganna')
+
+        self.assertIn('no weapon readied', self.ctx.sent().lower())
+        self.assertEqual(self.ally.ammo_rounds, 0)
 
     async def test_giving_own_readied_weapon_to_ally_clears_it(self):
         # Bug: GIVEing away your own currently-readied weapon left
@@ -453,9 +475,11 @@ class TestGiveWeaponAndAmmoToAlly(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(self.ally.ammo_rounds, 0)
 
     async def test_give_mismatched_ammo_after_weapon_is_rejected(self):
+        from commands.ready import ReadyCommand
         weapon = _make_weapon()
         self.player.inventory.add(weapon)
         await self.cmd.execute(self.ctx, '.357', 'magnum', 'to', 'morganna')
+        await ReadyCommand().execute(self.ctx, '.357')
 
         wrong_ammo = _make_ammo(name='.44 AMMO', item_id=105, used_with='.44 magnum')
         self.player.inventory.add(wrong_ammo)


### PR DESCRIPTION
## What

`GIVE <weapon> to <ally>` no longer auto-readies the weapon — it just stows it
in `ally.items`. The player decides when the ally actually wields it:

- `READY` (bare) / `ready <name>` now also enumerates each party ally's carried
  weapons; picking one toggles `ally.readied_weapon` (ready if unreadied, repack
  if already readied). Helpers: `_ally_weapon_entries` / `_ally_has_readied` /
  `_toggle_ally_weapon`. The player STR gate (`_MIN_STR`) only blocks the
  player's own weapons, never ally readying.
- `UNREADY <ally>` is the mirror toggle.
- Ammo (`GIVE ammo to <ally>`) still requires a *readied* ally weapon — READY first.

## Why

Alpha-tester feedback: it made no sense for an ally to instantly ready a weapon
the moment it was handed to them.

## Follow-ups

The parallel case — `give.py` still auto-*wears* armor/shield for allies
(`readied_armor` / `readied_shield`) — is untouched here; the same
READY/UNREADY-style toggle would extend to a WEAR-for-ally flow if testers object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)