### PR TITLE
Cap ally strength / to-hit / HP to SPUR ceilings; SPUR-faithful Fat Olaf MAINTAIN

### DIFF
--- a/server/bar/ally_data.py
+++ b/server/bar/ally_data.py
@@ -12,6 +12,47 @@ from base_classes import Gender, Alignment, HorseBreed, HorseColor
 _ROSTER_FILE = Path('run') / 'server' / 'net' / 'ally-roster.json'
 
 
+# ---------------------------------------------------------------------------
+# Canonical stat ceilings
+#
+# SPUR's sysop editor (SPUR.SYSOP.S ed.a.str / ed.a.hit) let an operator set
+# ally strength 1-20 and to-hit 1-9 (a percent-to-hit x10, so 9 == 90%).
+# Fat Olaf's hire adds a flat +5 on top of the catalog value (SPUR.BAR.S
+# buy: `a1 = x2 + 5`), so 25 is the highest strength a legitimately-obtained
+# ally can reach. SPUR has no separate ally hit-point stat at all -- combat
+# drains `a1` (strength) directly -- so the port's TADA-only
+# `hit_points = strength * HP_PER_STRENGTH` is bounded by the same ceiling.
+#
+# These are the single source of truth: bar/fat_olaf.py, street/allies_guild.py,
+# commands/editplayer.py, spells/charm.py and party.py all clamp against them,
+# and load_allies() / Party.from_json() re-clamp on load so a save that
+# predates the caps (or was hand-edited) self-heals on next login.
+ALLY_HP_PER_STRENGTH = 2
+ALLY_STRENGTH_MAX    = 25
+ALLY_TO_HIT_MIN      = 0    # SPUR's range is 1-9; 0 == "unused" (mounts sit here)
+ALLY_TO_HIT_MAX      = 9
+ALLY_HP_MAX          = ALLY_STRENGTH_MAX * ALLY_HP_PER_STRENGTH   # 50
+
+
+def clamp_ally_stats(ally: 'Ally') -> bool:
+    """Clamp *ally*'s strength / to_hit / hit_points into the canonical
+    ranges above, in place. Returns True if anything actually changed."""
+    changed = False
+    s = max(1, min(int(ally.strength or 1), ALLY_STRENGTH_MAX))
+    if s != ally.strength:
+        ally.strength = s
+        changed = True
+    t = max(ALLY_TO_HIT_MIN, min(int(ally.to_hit or 0), ALLY_TO_HIT_MAX))
+    if t != ally.to_hit:
+        ally.to_hit = t
+        changed = True
+    hp = max(0, min(int(ally.hit_points or 0), ALLY_HP_MAX))
+    if hp != (ally.hit_points or 0):
+        ally.hit_points = hp
+        changed = True
+    return changed
+
+
 class AllyFlags(Enum):
     GOD = auto()
     GODDESS = auto()
@@ -246,6 +287,21 @@ def save_ally_roster(allies: List['Ally']) -> None:
 _ALLIES_FILE = Path(__file__).parent.parent / 'allies.json'
 
 
+def base_ally_strength(name: str) -> Optional[int]:
+    """Return *name*'s pristine strength straight from allies.json, ignoring
+    any roster or session overrides. SPUR's Fat Olaf MAINTAIN (SPUR.BAR.S
+    `maint`) only restores a combat-drained ally back up to this catalog
+    value -- it's a repair, never a growth mechanic -- so bar/fat_olaf.py
+    needs the un-inflated number to know when to stop."""
+    try:
+        for entry in json.loads(_ALLIES_FILE.read_text()):
+            if entry.get('name') == name:
+                return entry.get('strength')
+    except Exception:
+        logging.exception('base_ally_strength: failed to read %s', _ALLIES_FILE)
+    return None
+
+
 def load_allies() -> list:
     """Loads ally information from allies.json (name, gender, strength,
     to_hit, flags, and an optional description shown by LOOK <ally> --
@@ -290,6 +346,12 @@ def load_allies() -> list:
             a.strength = entry['strength']
         if 'hit_points' in entry:
             a.hit_points = entry['hit_points']
+        # A roster written before the stat caps existed (or hand-edited)
+        # can carry a wildly inflated strength/HP -- pull it back into range
+        # so the ally self-heals on this load rather than needing a manual
+        # editplayer pass.
+        if clamp_ally_stats(a):
+            logging.info('load_allies: clamped out-of-range stats for %s', name)
 
     return ally_data
 

--- a/server/bar/fat_olaf.py
+++ b/server/bar/fat_olaf.py
@@ -15,7 +15,16 @@ import logging
 import random
 from typing import List, Optional
 
-from bar.ally_data import AllyFlags, AllyStatus, Ally, load_allies, save_ally_roster
+from bar.ally_data import (
+    ALLY_HP_MAX,
+    ALLY_STRENGTH_MAX,
+    AllyFlags,
+    AllyStatus,
+    Ally,
+    base_ally_strength,
+    load_allies,
+    save_ally_roster,
+)
 from bar.allies import pick_ally
 from base_classes import PlayerMoneyTypes
 from flags import PlayerFlags
@@ -29,6 +38,9 @@ _AP         = "'"
 _MAX_ALLIES = 3
 _STRENGTHEN_BASE_COST = 20   # cost per point of current strength (TADA extension)
 _HP_PER_STRENGTH      = 2    # hit_points seeded as strength × this on purchase (TADA extension)
+_HIRE_STR_BONUS       = 5    # flat strength added on hire (SPUR.BAR.S buy: a1 = x2 + 5)
+_FREE_SPIRIT_STR_CEIL = 15   # MAINTAIN target for an ally with no catalog entry
+                             # (SPUR.BAR.S maint: `if zs=0 x2=15`)
 _HONOR_SELL_LOSS      = 50   # honour lost when selling (t_bar_olaf.lbl :185)
 _HONOR_MAINTAIN_GAIN  = 5    # honour gained when maintaining (SPUR.BAR.S maint)
 
@@ -219,14 +231,16 @@ async def _buy_servant(ctx: GameContext, master_list: List[Ally]) -> None:
         player.unsaved_changes = True
         chosen.status = AllyStatus.SERVANT
         chosen.owner  = player.name
-        # Strength +5 on hire (SPUR.BAR.S: a1=x2+5 — ally is emboldened by new contract)
-        chosen.strength = chosen.strength + 5
+        # Strength +5 on hire (SPUR.BAR.S: a1=x2+5 — ally is emboldened by new
+        # contract), capped at the canonical ceiling (catalog max 20 + this
+        # bonus == ALLY_STRENGTH_MAX).
+        chosen.strength = min(chosen.strength + _HIRE_STR_BONUS, ALLY_STRENGTH_MAX)
         # Allies are created with hit_points=0 (bar/ally_data.py) and nothing else
         # initializes it, which left purchased allies unable to fight or take
         # damage (combat/engine.py gates ally participation on hit_points > 0).
         # Seed HP from strength on purchase (TADA extension; no canonical SPUR
         # source found for this formula).
-        chosen.hit_points = chosen.strength * _HP_PER_STRENGTH
+        chosen.hit_points = min(chosen.strength * _HP_PER_STRENGTH, ALLY_HP_MAX)
         save_ally_roster(master_list)
         await player.party.add(ctx, player, chosen)
         await ctx.send(f'{_NPC}: {_AP}May {chosen.name} serve yu vell!{_AP}')
@@ -310,13 +324,30 @@ async def _sell_servant(ctx: GameContext, master_list: List[Ally]) -> None:
 
 
 # ---------------------------------------------------------------------------
-# MAINTAIN  (SPUR.BAR.S maint — strengthens ally; honour +5)
+# MAINTAIN  (SPUR.BAR.S maint — restores a combat-drained ally; honour +5)
 #
 # t_bar_olaf.lbl routes this to {:999} (end label) — never implemented there.
-# SPUR.BAR.S has partial logic: reads new strength (x2), stores it back,
-# gives +5 honour, prints "Olaf does something mysterious... DER!! NAOW IZ BEDDER!!"
-# TADA fills in the cost and stat increase details.
+# SPUR.BAR.S `maint` is a *repair*, not a growth mechanic: it re-reads the
+# ally's catalog record (`gosub slv.srch` sets x2 = original strength, or
+# x2 = 15 for a free spirit), refuses once current >= that (`x2-zr < 1`),
+# charges `(x2 - zr) * 20` gold, then snaps strength straight back to the
+# catalog value (`a1 = x2`) and grants +5 honour (`vk = vk + 5 if vk < 2000`).
+# The earlier TADA port instead added random(1,3) every visit with no
+# ceiling, which is how allies ran away to absurd strength -- this restores
+# the SPUR behaviour, with the ceiling nudged up by the hire bonus so a
+# servant can be repaired to the strength it was actually bought at.
 # ---------------------------------------------------------------------------
+
+def _maintain_ceiling(ally: Ally) -> int:
+    """Highest strength MAINTAIN will restore *ally* to: its catalog value
+    plus the hire bonus (so a bought servant repairs to as-hired strength),
+    or _FREE_SPIRIT_STR_CEIL when it has no catalog entry -- never above
+    ALLY_STRENGTH_MAX."""
+    base = base_ally_strength(ally.name)
+    if base is None:
+        return _FREE_SPIRIT_STR_CEIL
+    return min(base + _HIRE_STR_BONUS, ALLY_STRENGTH_MAX)
+
 
 async def _maintain_servant(ctx: GameContext, master_list: List[Ally]) -> None:
     player = ctx.player
@@ -329,18 +360,29 @@ async def _maintain_servant(ctx: GameContext, master_list: List[Ally]) -> None:
             await ctx.send(f'{_NPC} shrugs. {_AP}Yu hav no servants to maintain!{_AP}')
         return
 
+    def _restore_cost(a: Ally) -> int:
+        return max(0, _maintain_ceiling(a) - a.strength) * _STRENGTHEN_BASE_COST
+
     await ctx.send('Servant condition:')
     chosen = await pick_ally(
         ctx, owned,
         f'{_NPC}: {_AP}Vich servant du yu vish to strengthen?{_AP}',
         extra_fn=lambda a: (f'HP: {a.hit_points}' if a.hit_points else 'HP: unknown')
-                           + f'  (strengthen: {a.strength * _STRENGTHEN_BASE_COST}s)',
+                           + (f'  (restore: {_restore_cost(a)}s)' if _restore_cost(a)
+                              else '  (at full strength)'),
         # invalid_msg=f'{_NPC}: {_AP}Com com, 1 teu {{len(owned)}}! (Enter aborts){_AP}',
     )
     if chosen is None:
         await ctx.send(f'{_NPC} shrugs.')
         return
-    cost   = chosen.strength * _STRENGTHEN_BASE_COST
+
+    ceiling = _maintain_ceiling(chosen)
+    if chosen.strength >= ceiling:
+        # SPUR: `if (x2-zr) < 1 print "I CON DU NUTIN VER HIM!"` -- no charge.
+        await ctx.send(f'{_NPC} looks {chosen.name} over. {_AP}I con du nutin ver him!{_AP}')
+        return
+
+    cost   = _restore_cost(chosen)
     silver = player.get_silver(PlayerMoneyTypes.IN_HAND)
 
     raw2 = await ctx.prompt(
@@ -357,9 +399,9 @@ async def _maintain_servant(ctx: GameContext, master_list: List[Ally]) -> None:
         return
 
     player.subtract_silver(PlayerMoneyTypes.IN_HAND, cost)
-    # Strengthen (SPUR.BAR.S: updates x2 new-strength back into slot)
-    gain = random.randint(1, 3)
-    chosen.strength += gain
+    # SPUR.BAR.S: `a1 = x2` — strength snaps back to the catalog ceiling.
+    gained = ceiling - chosen.strength
+    chosen.strength = ceiling
     _sync_to_roster(master_list, chosen.name, chosen.status, chosen.owner, chosen.strength)
     # Honour bonus for investing in servant (SPUR.BAR.S: vk=vk+5 if vk<2000)
     if getattr(player, 'honor', 0) < 2000:
@@ -369,7 +411,7 @@ async def _maintain_servant(ctx: GameContext, master_list: List[Ally]) -> None:
     await ctx.send([
         f'Olaf does something mysterious...',
         f'{_NPC}: {_AP}Der!! Naow iz bedder!!{_AP}',
-        f'{chosen.name} gained {gain} strength (now {chosen.strength}).',
+        f'{chosen.name} recovered {gained} strength (now {chosen.strength}).',
     ])
 
 

--- a/server/commands/cast.py
+++ b/server/commands/cast.py
@@ -265,7 +265,7 @@ def _cast_resurrect(player, success: bool) -> tuple[str, str]:
     "brought back to life" target this port actually tracks. Backfire
     strikes a living Ally unconscious instead, the same "real downside,
     not just flavor" shape as every other spell's backfire."""
-    from bar.ally_data import AllyStatus
+    from bar.ally_data import ALLY_HP_MAX, AllyStatus
     from bar.fat_olaf import _HP_PER_STRENGTH
 
     allies = [m for m in (getattr(player, 'party', None) or []) if hasattr(m, 'status')]
@@ -276,7 +276,7 @@ def _cast_resurrect(player, success: bool) -> tuple[str, str]:
         if target is None:
             return 'success', 'The spell finds no one in need of resurrection.'
         target.status = AllyStatus.SERVANT
-        target.hit_points = target.strength * _HP_PER_STRENGTH
+        target.hit_points = min(target.strength * _HP_PER_STRENGTH, ALLY_HP_MAX)
         player.unsaved_changes = True
         return 'success', f'{target.name} gasps and returns to life!'
 

--- a/server/commands/editplayer.py
+++ b/server/commands/editplayer.py
@@ -8,7 +8,9 @@ Menu layout mirrors the original C64 TADA Player Editor (tep v2.07):
   ├─  1. Alignment         natural + current alignment
   ├─  2. Armor/Shield      armor / shield protection values, shield skill
   ├─  3. Attributes        stats (CHR, CON, DEX, INT, STR, WIS, Energy)
-  ├─  4. Character Names   player name; rename allies and horse
+  ├─  4. Character / NPC Stats  player name; rename allies & horse, and
+  │                        edit their strength / to-hit / HP (clamped to
+  │                        the SPUR ceilings in bar/ally_data.py)
   ├─  5. Combinations      locker, elevator, castle, booby traps
   ├─  6. Command Settings  player.command_settings toggles (e.g. whereat hiding)
   ├─  7. Flags/Counters    all PlayerFlags grouped by category
@@ -460,7 +462,7 @@ def _build_main_menu(ctx) -> Menu:
     menu.add_item(MenuItem('Alignment',        shortcuts='al', submenu=_alignment_menu(ctx)))
     menu.add_item(MenuItem('Armor/Shield',     shortcuts='as', submenu=_armor_shield_menu(ctx)))
     menu.add_item(MenuItem('Attributes',       shortcuts='at', submenu=_attributes_menu(ctx)))
-    menu.add_item(MenuItem('Character Names',  shortcuts='cn', submenu=_names_menu(ctx)))
+    menu.add_item(MenuItem('Character / NPC Stats', shortcuts='cn', submenu=_names_menu(ctx)))
     menu.add_item(MenuItem('Combinations',     shortcuts='co', submenu=_combinations_menu(ctx)))
     menu.add_item(MenuItem('Command Settings', shortcuts='cs', submenu=_command_settings_menu(ctx)))
     menu.add_item(MenuItem('Flags/Counters',   shortcuts='fl', submenu=_flags_menu(ctx)))
@@ -1060,12 +1062,59 @@ async def _rename_ally(ctx, ally) -> None:
     await ctx.send(f'{old} renamed to {ally.name}.')
 
 
+async def _edit_ally_stats(ctx, ally) -> None:
+    """Edit an ally's (or the horse's) strength / to-hit / HP, each clamped
+    to the canonical SPUR ceilings in bar/ally_data.py (ALLY_STRENGTH_MAX 25,
+    to-hit 0-9, ALLY_HP_MAX 50). Loops so several stats can be set in one
+    visit; blank input finishes."""
+    from bar.ally_data import (
+        ALLY_HP_MAX, ALLY_STRENGTH_MAX, ALLY_TO_HIT_MAX, ALLY_TO_HIT_MIN,
+    )
+
+    while True:
+        raw = await ctx.prompt(
+            f'{ally.name} stats',
+            preamble_lines=[
+                f'Current:  Str {ally.strength}   '
+                f'To-hit {ally.to_hit} ({ally.to_hit * 10}%)   '
+                f'HP {ally.hit_points}',
+                f"[S]trength, [T]o-hit, [H]P, or {ctx.player.return_key} to finish:",
+            ],
+        )
+        choice = (raw or '').strip().lower()
+        if not choice:
+            return
+        if choice == 's':
+            val = await _prompt_int(ctx, f'{ally.name} strength',
+                                    ally.strength, 1, ALLY_STRENGTH_MAX)
+            if val is not None:
+                ally.strength = val
+                ctx.player.unsaved_changes = True
+                await ctx.send(f'{ally.name} strength set to {val}.')
+        elif choice == 't':
+            val = await _prompt_int(ctx, f'{ally.name} to-hit (x10 = %)',
+                                    ally.to_hit, ALLY_TO_HIT_MIN, ALLY_TO_HIT_MAX)
+            if val is not None:
+                ally.to_hit = val
+                ctx.player.unsaved_changes = True
+                await ctx.send(f'{ally.name} to-hit set to {val} ({val * 10}%).')
+        elif choice == 'h':
+            val = await _prompt_int(ctx, f'{ally.name} hit points',
+                                    ally.hit_points or 0, 0, ALLY_HP_MAX)
+            if val is not None:
+                ally.hit_points = val
+                ctx.player.unsaved_changes = True
+                await ctx.send(f'{ally.name} hit points set to {val}.')
+        else:
+            await ctx.send("Please choose 'S', 'T', or 'H'.")
+
+
 def _names_menu(ctx) -> Menu:
     from bar.allies import owned_allies
     from bar.ally_data import AllyFlags, AllyStatus
 
     p    = ctx.player
-    menu = _titled_menu(ctx, 'Character Names')
+    menu = _titled_menu(ctx, 'Character / NPC Stats')
 
     async def edit_name(ctx) -> None:
         raw = await ctx.prompt(
@@ -1225,8 +1274,9 @@ def _names_menu(ctx) -> Menu:
         raw = await ctx.prompt(
             ally.name,
             preamble_lines=[
-                f'Current: {ally.name}  Str {ally.strength}  {ally.to_hit * 10}%',
-                f"[N]ew name, [S]wap for a different ally, or "
+                f'Current: {ally.name}  Str {ally.strength}  {ally.to_hit * 10}%'
+                f'  HP {ally.hit_points}',
+                f"[N]ew name, [S]wap for a different ally, [E]dit stats, or "
                 f"{ctx.player.return_key} to cancel:",
             ],
         )
@@ -1237,8 +1287,10 @@ def _names_menu(ctx) -> Menu:
             await _rename_ally(ctx, ally)
         elif choice == 's':
             await _swap_ally(ctx, slot)
+        elif choice == 'e':
+            await _edit_ally_stats(ctx, ally)
         else:
-            await ctx.send("Please choose 'N' or 'S'.")
+            await ctx.send("Please choose 'N', 'S', or 'E'.")
 
     def _horse() -> Optional[object]:
         return next((a for a in owned_allies(p) if AllyFlags.MOUNT in (a.flags or [])), None)
@@ -1350,8 +1402,10 @@ def _names_menu(ctx) -> Menu:
             return
 
         bolted = mount.status == AllyStatus.BOLTED
-        options = "[N]ew name, [R]emove horse" + (", [C] recall bolted horse" if bolted else "")
-        current_line = f'Current: {mount.name}  Str {mount.strength}'
+        options = ("[N]ew name, [R]emove horse, [E]dit stats"
+                   + (", [C] recall bolted horse" if bolted else ""))
+        current_line = (f'Current: {mount.name}  Str {mount.strength}  '
+                        f'{mount.to_hit * 10}%  HP {mount.hit_points}')
         if bolted:
             current_line += f'  [BOLTED -- Level {mount.bolt_map_level} Room {mount.bolt_room_no}]'
         raw = await ctx.prompt(
@@ -1368,10 +1422,12 @@ def _names_menu(ctx) -> Menu:
             await _rename_ally(ctx, mount)
         elif choice == 'r':
             await _remove_horse(ctx)
+        elif choice == 'e':
+            await _edit_ally_stats(ctx, mount)
         elif choice == 'c' and bolted:
             await _recall_horse(ctx)
         else:
-            expected = 'N, R, or C' if bolted else "'N' or 'R'"
+            expected = 'N, R, E, or C' if bolted else "'N', 'R', or 'E'"
             await ctx.send(f"Please choose {expected}.")
 
     def _roster_label(a) -> str:

--- a/server/party.py
+++ b/server/party.py
@@ -176,7 +176,9 @@ class Party:
             member_type = item.get('type')
             try:
                 if member_type == 'ally':
-                    from bar.ally_data import Ally, AllyFlags, AllyPosition, AllyStatus
+                    from bar.ally_data import (
+                        Ally, AllyFlags, AllyPosition, AllyStatus, clamp_ally_stats,
+                    )
                     from base_classes import HorseBreed, HorseColor
                     from inventory import Inventory
                     flags = [
@@ -191,6 +193,10 @@ class Party:
                         flags,
                     )
                     ally.hit_points = item.get('hit_points', 0)
+                    # Clamp saves that predate the stat caps (bar/ally_data.py's
+                    # ALLY_STRENGTH_MAX etc.) or were hand-edited -- the ally
+                    # comes back in range instead of keeping a runaway value.
+                    clamp_ally_stats(ally)
                     breed_name = item.get('breed')
                     if breed_name in HorseBreed.__members__:
                         ally.breed = HorseBreed[breed_name]

--- a/server/spells/charm.py
+++ b/server/spells/charm.py
@@ -239,6 +239,11 @@ async def try_charm_join_offer(ctx: 'GameContext', *, level: int, room_no: int) 
     ally.status = AllyStatus.SERVANT
     ally.owner  = player.name
     ally.hit_points = pending['strength'] * _HP_PER_STRENGTH
+    # A charmed monster inherits its (sysop-capped 1-18) monster strength,
+    # so it's already in range, but clamp for belt-and-suspenders parity
+    # with every other ally-creation path.
+    from bar.ally_data import clamp_ally_stats
+    clamp_ally_stats(ally)
 
     player.party.add_member(player, ally)
     player.charmed_monsters.append(pending['monster_number'])

--- a/server/street/allies_guild.py
+++ b/server/street/allies_guild.py
@@ -21,7 +21,7 @@ SPUR notes:
 import logging
 from typing import List, Optional
 
-from bar.ally_data import Ally, AllyFlags
+from bar.ally_data import ALLY_STRENGTH_MAX, Ally, AllyFlags
 from bar.allies import owned_allies, pick_ally
 from base_classes import PlayerMoneyTypes
 from network_context import GameContext
@@ -103,11 +103,16 @@ async def _train_body(ctx: GameContext, ally: Ally) -> None:
     if level >= _MAX_BODY_BUILD_LEVEL:
         await ctx.send(f'{ally.name} already is as large as possible!')
         return
+    # A +3 level would overshoot the canonical strength ceiling (catalog 20 +
+    # Olaf's hire bonus) -- refuse rather than sell training that can't land.
+    if ally.strength >= ALLY_STRENGTH_MAX:
+        await ctx.send(f'{ally.name} is already as strong as any ally can be!')
+        return
     cost = (level + 1) * _BODY_BUILD_BASE_COST
     if not await _confirm_and_charge(ctx, ally, f'body built +{_BODY_BUILD_STR_BONUS}', cost):
         return
     ally.body_build = level + 1
-    ally.strength += _BODY_BUILD_STR_BONUS
+    ally.strength = min(ally.strength + _BODY_BUILD_STR_BONUS, ALLY_STRENGTH_MAX)
     await ctx.send(f'{ally.name} is now BODY BUILT +{_BODY_BUILD_STR_BONUS}!  (Str {ally.strength})')
     import net_common
     net_common.append_battle_log(

--- a/server/tests/admin/test_editplayer.py
+++ b/server/tests/admin/test_editplayer.py
@@ -77,6 +77,12 @@ class _MockPlayer:
         self.food               = 20
         self.drink              = 20
         self._held_items: set   = set()
+        self.party: list        = []
+        self.unsaved_changes    = False
+
+    @property
+    def return_key(self) -> str:
+        return self.client_settings.return_key
 
     def has_item(self, *, name=None, item_id=None, category=None) -> bool:
         return name is not None and name.upper() in self._held_items
@@ -235,7 +241,7 @@ class TestMenuStructure(unittest.TestCase):
     def test_main_menu_contains_expected_labels(self):
         labels = {i.text for i in _build_main_menu(self.ctx).selectable}
         for name in ('Alignment', 'Attributes', 'Flags/Counters',
-                     'Statistics', 'Character Names', 'Combinations',
+                     'Statistics', 'Character / NPC Stats', 'Combinations',
                      'Hit Points', 'Money', 'Weapons'):
             self.assertIn(name, labels, f'{name!r} missing from main menu')
 
@@ -750,11 +756,11 @@ class TestIntegration(unittest.IsolatedAsyncioTestCase):
     navigate_menu calls ctx.prompt('Choice', ...) after every menu display.
     Inline action prompts (_prompt_int, list pickers) also consume items.
 
-    Flags/Counters is item 6 in the main menu.
+    Flags/Counters is item 7 in the main menu.
     Expert Mode is item 1 in the flags menu.
 
     Scripted navigation to toggle Expert Mode and return:
-        Main displayed   → '6'  → push Flags submenu
+        Main displayed   → '7'  → push Flags submenu
         Flags displayed  → '1'  → run toggle action
         Flags displayed  → ''   → pop Flags submenu
         Main displayed   → ''   → pop main menu, done
@@ -770,6 +776,7 @@ class TestIntegration(unittest.IsolatedAsyncioTestCase):
         self.assertGreater(len(ctx.sent), 0)
 
     async def test_toggle_expert_mode_via_navigation(self):
+        # Main → Flags/Counters (7) → Expert Mode (1) → up → up
         ctx = _MockCtx(responses=['7', '1', '', ''])
         self.assertFalse(ctx.player.query_flag(PlayerFlags.EXPERT_MODE))
         await EditPlayerCommand().execute(ctx)
@@ -818,6 +825,63 @@ class TestIntegration(unittest.IsolatedAsyncioTestCase):
                or ctx.player.combinations.get(combo_type.name))
         self.assertIsNotNone(obj)
         self.assertEqual(obj.combination, (4, 5, 9))
+
+
+# ---------------------------------------------------------------------------
+# 10. Character / NPC Stats — _edit_ally_stats (strength / to-hit / HP,
+#     clamped to bar/ally_data.py's canonical SPUR ceilings)
+# ---------------------------------------------------------------------------
+
+class TestEditAllyStats(unittest.IsolatedAsyncioTestCase):
+
+    def _ally(self, name='ROBIN', strength=9, to_hit=4, hp=18):
+        from bar.ally_data import Ally, AllyStatus
+        a = Ally(name, 'm', strength, to_hit, [])
+        a.status = AllyStatus.SERVANT
+        a.hit_points = hp
+        return a
+
+    async def test_edit_strength_sets_value_and_marks_unsaved(self):
+        from commands.editplayer import _edit_ally_stats
+        ally = self._ally(strength=25)
+        ctx  = _MockCtx(responses=['s', '12', ''])
+        await _edit_ally_stats(ctx, ally)
+        self.assertEqual(ally.strength, 12)
+        self.assertTrue(ctx.player.unsaved_changes)
+
+    async def test_edit_to_hit_and_hp_in_one_visit(self):
+        from commands.editplayer import _edit_ally_stats
+        ally = self._ally(to_hit=4, hp=18)
+        ctx  = _MockCtx(responses=['t', '7', 'h', '30', ''])
+        await _edit_ally_stats(ctx, ally)
+        self.assertEqual(ally.to_hit, 7)
+        self.assertEqual(ally.hit_points, 30)
+
+    async def test_strength_above_cap_is_rejected(self):
+        from bar.ally_data import ALLY_STRENGTH_MAX
+        from commands.editplayer import _edit_ally_stats
+        ally = self._ally(strength=10)
+        # 99 is over ALLY_STRENGTH_MAX (25) -> _prompt_int loops, then blank
+        # cancels the sub-prompt, then blank finishes the stat menu.
+        ctx  = _MockCtx(responses=['s', str(ALLY_STRENGTH_MAX + 74), '', ''])
+        await _edit_ally_stats(ctx, ally)
+        self.assertEqual(ally.strength, 10)
+
+    async def test_hp_above_cap_is_rejected(self):
+        from bar.ally_data import ALLY_HP_MAX
+        from commands.editplayer import _edit_ally_stats
+        ally = self._ally(hp=20)
+        ctx  = _MockCtx(responses=['h', str(ALLY_HP_MAX + 1), '', ''])
+        await _edit_ally_stats(ctx, ally)
+        self.assertEqual(ally.hit_points, 20)
+
+    async def test_blank_first_input_is_a_no_op(self):
+        from commands.editplayer import _edit_ally_stats
+        ally = self._ally(strength=9)
+        ctx  = _MockCtx(responses=[''])
+        await _edit_ally_stats(ctx, ally)
+        self.assertEqual(ally.strength, 9)
+        self.assertFalse(ctx.player.unsaved_changes)
 
 
 # ---------------------------------------------------------------------------

--- a/server/tests/admin/test_editplayer_new_features.py
+++ b/server/tests/admin/test_editplayer_new_features.py
@@ -6,7 +6,7 @@ out with _not_implemented() before this session:
   - Armor/Shield menu    (main menu)
   - Map Information menu (main menu)
   - Weapons menu         (main menu: readied weapon, battle experience)
-  - Character Names      (Ally 1-3, Horse rename)
+  - Character / NPC Stats (Ally 1-3, Horse rename + stat editing)
   - Statistics           (Birthday, Experience, Moves to date, Monsters killed)
 
 Run with:
@@ -398,7 +398,7 @@ class TestWeaponsMenu(unittest.IsolatedAsyncioTestCase):
 
 
 # ---------------------------------------------------------------------------
-# Character Names — Ally slots + Horse
+# Character / NPC Stats — Ally slots + Horse
 # ---------------------------------------------------------------------------
 
 class TestNamesMenuHorseDoesNotOccupyAllySlot(unittest.IsolatedAsyncioTestCase):
@@ -517,7 +517,7 @@ class TestNamesMenuAllyAndHorse(unittest.IsolatedAsyncioTestCase):
         ctx = _FakeCtx(responses=['X'], player=player)
         menu = _names_menu(ctx)
         await _find_item(menu, 'Ally 1').action(ctx)
-        self.assertIn("Please choose 'N' or 'S'.", ctx.sent[-1])
+        self.assertIn("Please choose 'N', 'S', or 'E'.", ctx.sent[-1])
         self.assertEqual(ally.name, 'EMMETT "DOC" BROWN')
 
     async def test_second_empty_slot_reports_no_ally(self):

--- a/server/tests/bar/test_ally_stat_caps.py
+++ b/server/tests/bar/test_ally_stat_caps.py
@@ -1,0 +1,102 @@
+"""tests/bar/test_ally_stat_caps.py
+
+The canonical ally stat ceilings (bar/ally_data.py) and the SPUR-faithful
+Fat Olaf MAINTAIN ceiling (bar/fat_olaf.py).
+
+SPUR limits (via SPUR-code/SPUR.SYSOP.S ed.a.str / ed.a.hit and SPUR.BAR.S):
+  - sysop could set ally strength 1-20, to-hit 1-9
+  - Fat Olaf's hire adds a flat +5  (buy: a1 = x2 + 5)  -> 25 is the true max
+  - SPUR has no ally-HP stat; the port's hit_points = strength * 2 -> 50 max
+  - MAINTAIN only restores a drained ally back up to its catalog strength
+    (or 15 for a free spirit) -- never grows it past that
+"""
+import json
+import unittest
+
+from bar.ally_data import (
+    ALLY_HP_MAX,
+    ALLY_STRENGTH_MAX,
+    ALLY_TO_HIT_MAX,
+    ALLY_TO_HIT_MIN,
+    Ally,
+    AllyStatus,
+    base_ally_strength,
+    clamp_ally_stats,
+    _ALLIES_FILE,
+)
+
+
+def _ally(strength=10, to_hit=4, hp=20, name='ROBIN'):
+    a = Ally(name, 'm', strength, to_hit, [])
+    a.status = AllyStatus.SERVANT
+    a.hit_points = hp
+    return a
+
+
+class TestCanonicalCeilings(unittest.TestCase):
+
+    def test_values_match_spur(self):
+        self.assertEqual(ALLY_STRENGTH_MAX, 25)
+        self.assertEqual(ALLY_TO_HIT_MIN, 0)
+        self.assertEqual(ALLY_TO_HIT_MAX, 9)
+        self.assertEqual(ALLY_HP_MAX, 50)
+
+
+class TestClampAllyStats(unittest.TestCase):
+
+    def test_in_range_is_untouched(self):
+        a = _ally(strength=12, to_hit=5, hp=24)
+        self.assertFalse(clamp_ally_stats(a))
+        self.assertEqual((a.strength, a.to_hit, a.hit_points), (12, 5, 24))
+
+    def test_runaway_values_are_pulled_back(self):
+        a = _ally(strength=180, to_hit=40, hp=999)
+        self.assertTrue(clamp_ally_stats(a))
+        self.assertEqual(a.strength, ALLY_STRENGTH_MAX)
+        self.assertEqual(a.to_hit, ALLY_TO_HIT_MAX)
+        self.assertEqual(a.hit_points, ALLY_HP_MAX)
+
+    def test_floor_is_enforced(self):
+        a = _ally(strength=0, to_hit=-3, hp=-10)
+        self.assertTrue(clamp_ally_stats(a))
+        self.assertEqual(a.strength, 1)
+        self.assertEqual(a.to_hit, ALLY_TO_HIT_MIN)
+        self.assertEqual(a.hit_points, 0)
+
+
+class TestBaseAllyStrength(unittest.TestCase):
+
+    def test_reads_pristine_value_from_json(self):
+        raw = {e['name']: e['strength'] for e in json.loads(_ALLIES_FILE.read_text())}
+        # pick any real catalog ally and confirm we get its json strength back
+        name, strength = next(iter(raw.items()))
+        self.assertEqual(base_ally_strength(name), strength)
+
+    def test_unknown_name_returns_none(self):
+        self.assertIsNone(base_ally_strength('NOT A REAL ALLY 12345'))
+
+
+class TestMaintainCeiling(unittest.TestCase):
+
+    def test_catalog_ally_ceiling_is_base_plus_hire_bonus(self):
+        from bar.fat_olaf import _HIRE_STR_BONUS, _maintain_ceiling
+        name = next(iter(json.loads(_ALLIES_FILE.read_text())))['name']
+        base = base_ally_strength(name)
+        a = _ally(name=name, strength=1)
+        expected = min(base + _HIRE_STR_BONUS, ALLY_STRENGTH_MAX)
+        self.assertEqual(_maintain_ceiling(a), expected)
+
+    def test_free_spirit_ceiling_is_fifteen(self):
+        from bar.fat_olaf import _FREE_SPIRIT_STR_CEIL, _maintain_ceiling
+        a = _ally(name='SOME CHARMED THING', strength=1)
+        self.assertEqual(_maintain_ceiling(a), _FREE_SPIRIT_STR_CEIL)
+
+    def test_ceiling_never_exceeds_strength_max(self):
+        from bar.fat_olaf import _maintain_ceiling
+        for entry in json.loads(_ALLIES_FILE.read_text()):
+            a = _ally(name=entry['name'], strength=1)
+            self.assertLessEqual(_maintain_ceiling(a), ALLY_STRENGTH_MAX)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/server/tests/combat/test_allies_guild.py
+++ b/server/tests/combat/test_allies_guild.py
@@ -227,6 +227,29 @@ class TestAllyGuildTraining(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(player._gold, 5000)
         self.assertIn('as large as possible', ctx.sent())
 
+    async def test_body_build_refused_at_strength_ceiling(self):
+        from bar.ally_data import ALLY_STRENGTH_MAX
+        ally = _make_ally()
+        ally.strength = ALLY_STRENGTH_MAX      # already maxed, but level < 8
+        ally.body_build = 2
+        player = _FakePlayer(gold=5000, allies=[ally])
+        ctx = _FakeCtx(player)
+        await _train_body(ctx, ally)           # no answers queued -- must not prompt
+        self.assertEqual(ally.strength, ALLY_STRENGTH_MAX)
+        self.assertEqual(ally.body_build, 2)
+        self.assertEqual(player._gold, 5000)
+        self.assertIn('as strong as any ally can be', ctx.sent())
+
+    async def test_body_build_gain_clamped_to_strength_ceiling(self):
+        from bar.ally_data import ALLY_STRENGTH_MAX
+        ally = _make_ally()
+        ally.strength = ALLY_STRENGTH_MAX - 1  # a +3 would overshoot by 2
+        player = _FakePlayer(gold=5000, allies=[ally])
+        ctx = _FakeCtx(player)
+        ctx.set_answers(['Y'])
+        await _train_body(ctx, ally)
+        self.assertEqual(ally.strength, ALLY_STRENGTH_MAX)
+
 
 class TestAllyGuildMain(unittest.IsolatedAsyncioTestCase):
 


### PR DESCRIPTION
> #34 (`ready-ally-weapons`) is merged; this PR now targets `master` directly.

## Problem

Ally stats had no ceiling and ran away to absurd values. Growth paths, none
capped:

- **Fat Olaf MAINTAIN** added `random(1,3)` strength every visit, forever — the
  runaway.
- Hiring adds a flat `+5`; the Allies' Guild adds `+3` per body-build level.
- HP is re-seeded as `strength × 2` on hire, RESURRECT, charm, and mount feeding.

## Canonical SPUR limits (from `SPUR-code/` + `programming-notes/spur-variables.md`)

| Stat | Ceiling | Source |
|---|---|---|
| Strength | **25** (sysop max 20 + Fat Olaf `+5` hire) | `SPUR.SYSOP.S ed.a.str`, `SPUR.BAR.S buy` |
| To-hit | **0–9** (×10 = 0–90%) | `SPUR.SYSOP.S ed.a.hit` |
| HP | **50** — SPUR has *no* ally-HP stat; combat drains strength itself. Port's `strength × 2` is bounded by the strength cap | — |
| Body building | 1–8 levels, +3 each (already capped) | skip-branch `SPUR.MISC8.S s.bod` |
| MAINTAIN | *repair only* — restore to catalog strength (15 for a free spirit), refuse there, no bonus | `SPUR.BAR.S maint` |

## Changes

- **`bar/ally_data.py`** — `ALLY_STRENGTH_MAX` / `ALLY_TO_HIT_MIN`/`MAX` /
  `ALLY_HP_MAX` constants, `clamp_ally_stats()` (single source of truth),
  `base_ally_strength()` (pristine value from `allies.json`). `load_allies()`
  re-clamps roster overrides.
- **`party.py`** — `Party.from_json` clamps every ally on load, so existing
  inflated saves self-heal on next login.
- **`bar/fat_olaf.py`** — hire `+5` clamped; MAINTAIN rewritten to the SPUR
  repair-to-ceiling behaviour (`_maintain_ceiling` = `min(catalog+5, 25)` or 15
  free-spirit) — refuses at the ceiling, cost `(ceiling−cur)×20`, snaps strength
  to the ceiling instead of growing it randomly.
- **`street/allies_guild.py`** — body building refuses at `ALLY_STRENGTH_MAX`
  and clamps the `+3`.
- **`commands/editplayer.py`** — "Character Names" → **"Character / NPC Stats"**;
  new `_edit_ally_stats()` reachable via `[E]dit stats` on the per-slot ally and
  horse prompts (strength / to-hit / HP, all clamped).
- **`spells/charm.py`**, **`commands/cast.py`** (RESURRECT) — defensive clamp on
  the HP-from-strength seed.

## Tests

New `tests/bar/test_ally_stat_caps.py`; guild strength-ceiling cases;
`TestEditAllyStats` in `test_editplayer.py`. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
