### PR TITLE
give: ally pick-list for bare 'give <item>'; drink: pool confirmation line

### DIFF
--- a/server/commands/drink.py
+++ b/server/commands/drink.py
@@ -60,7 +60,10 @@ class DrinkCommand(Command):
         if room is not None and getattr(room, 'food', 0) == _POOL_OF_WATER_ID:
             from config import config
             restore_drink(player, config.survival_max)
-            await ctx.send('You kneel and drink your fill..')
+            non_expert = " (Your thirst has been quenched.)" \
+                if player.drink is not None \
+                and not player.is_expert else ''
+            await ctx.send(f'You kneel and drink your fill.{non_expert}')
             return CommandResult.ok()
 
         entries = _drink_entries(player)


### PR DESCRIPTION
> #34 (`ready-ally-weapons`) is merged; this PR now targets `master` directly.
> Two unrelated small polish commits bundled together.

## `2d7eb28` — give: offer an ally pick list when `give <item>` has no target

Bare `give <item>` with no `to <name>` previously just errored. Now, if the
player has purchased allies, it prints a numbered list and prompts for a choice
(as guided as bare `give` already is for picking the item). With no allies, the
old "Give it to whom?" hint is kept.

`test_give_take.py`: `test_give_no_target_asks_whom` split into the list case
(allies present) and the "whom" case (ally removed first).

## `ed9ed59` — drink: non-expert confirmation line when drinking from a pool

The pool-of-water branch printed only "You kneel and drink your fill.." with no
feedback that thirst was actually restored. Appends
"(Your thirst has been quenched.)" for non-expert players, matching the
verbose/non-expert messaging pattern used elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
