### PR TITLE
Prompt/action-key display fixes for alpha testers

### DIFF
--- a/server/TODO.md
+++ b/server/TODO.md
@@ -1,4 +1,29 @@
-8/15/26:
+9/3/26:
+- **`%k` substitute_tokens() token for the player's Return/Enter key
+  label.** `tada_utilities.substitute_tokens()` already runs every
+  outgoing line through %-token substitution (%n name, %s/%o/%p/%P/%r
+  pronouns, %c class, %e race -- see its docstring), and `ctx.send()`
+  applies it automatically to every line sent (`network_context.py`).
+  A `%k` token resolving to `subject.return_key` (falling back to
+  `'Enter'` if the subject doesn't expose it, same fallback the
+  property itself uses -- see `player.py`'s `Player.return_key`) would
+  let *static* text -- anything that can't reach a live `ctx.player` at
+  construction time -- reference the player's negotiated key label the
+  same way dynamic f-string prompts already do via
+  `{ctx.player.return_key}`. Concrete motivating case:
+  `commands/more_prompt.py`'s `Help(description=...)` hardcodes "Enter"
+  in its help text (`"...pauses with a '-- More --' prompt between
+  pages (Enter for next, B/- for back, Q to stop)..."`) -- `Help` is a
+  dataclass built once at class-definition time with no `ctx` in scope,
+  so it can't currently be written as an f-string the way ~100+ other
+  prompt call sites were converted to do (see the "Wrap long
+  ctx.prompt() option text into preamble_lines" branch/commit, which
+  also swept most hardcoded "Enter" strings elsewhere in the codebase
+  to `{ctx.player.return_key}` but explicitly left this one as a TODO
+  rather than bolt on new templating machinery unprompted). Once `%k`
+  exists, `more_prompt.py`'s description (and any other static
+  Help()/flavor text baking in "Enter") can switch to it. Not yet
+  scoped/implemented -- just the idea captured here.
 - **Server config option: spoils-splitting mode.** Monster kill silver
   currently always splits evenly across every credited attacker
   (`combat/engine.py`'s `_monster_dies()`, see the "Silver loot" block --

--- a/server/ally_events/capture_horse.py
+++ b/server/ally_events/capture_horse.py
@@ -69,7 +69,9 @@ async def prompt_horse_name(ctx: 'GameContext', gender: str = 'm') -> Optional[s
     bare 'R' doesn't get rejected as "too short".
     """
     while True:
-        raw = await ctx.prompt("Name your horse (4-12 chars, 'R' for random, Enter to cancel)")
+        raw = await ctx.prompt(
+            'Horse name',
+            preamble_lines=["Name your horse (4-12 chars, 'R' for random, Enter to cancel)"])
         if not raw or not raw.strip():
             return None
         name = raw.strip()

--- a/server/ally_events/capture_horse.py
+++ b/server/ally_events/capture_horse.py
@@ -71,7 +71,7 @@ async def prompt_horse_name(ctx: 'GameContext', gender: str = 'm') -> Optional[s
     while True:
         raw = await ctx.prompt(
             'Horse name',
-            preamble_lines=["Name your horse (4-12 chars, 'R' for random, Enter to cancel)"])
+            preamble_lines=[f"Name your horse (4-12 chars, 'R' for random, {ctx.player.return_key} to cancel)"])
         if not raw or not raw.strip():
             return None
         name = raw.strip()

--- a/server/ally_events/capture_horse.py
+++ b/server/ally_events/capture_horse.py
@@ -71,7 +71,7 @@ async def prompt_horse_name(ctx: 'GameContext', gender: str = 'm') -> Optional[s
     while True:
         raw = await ctx.prompt(
             'Horse name',
-            preamble_lines=[f"Name your horse (4-12 chars, 'R' for random, {ctx.player.return_key} to cancel)"])
+            preamble_lines=[f"Name your horse (4-12 chars, [R]andom, {ctx.player.return_key} to cancel)"])
         if not raw or not raw.strip():
             return None
         name = raw.strip()

--- a/server/annex/main.py
+++ b/server/annex/main.py
@@ -181,7 +181,7 @@ async def main(ctx: GameContext) -> None:
         if matched:
             await matched(ctx)
         else:
-            await ctx.send(f'"{raw.strip()}"? (Enter a number 1–17, or X to leave)')
+            await ctx.send(f'"{raw.strip()}"? (Enter a number 1–17, or [X] Leave)')
 
 
 # ---------------------------------------------------------------------------

--- a/server/bar/allies.py
+++ b/server/bar/allies.py
@@ -88,7 +88,7 @@ async def pick_ally(
 
     raw = await ctx.prompt(
         'Choice',
-        preamble_lines=[f'{prompt} (1-{len(allies)}, Enter to cancel)'])
+        preamble_lines=[f'{prompt} (1-{len(allies)}, {ctx.player.return_key} to cancel)'])
     if not raw or not raw.strip():
         return None
     try:

--- a/server/bar/allies.py
+++ b/server/bar/allies.py
@@ -86,7 +86,9 @@ async def pick_ally(
     lines.append('')
     await ctx.send(lines)
 
-    raw = await ctx.prompt(f'{prompt} (1-{len(allies)}, Enter to cancel)')
+    raw = await ctx.prompt(
+        'Choice',
+        preamble_lines=[f'{prompt} (1-{len(allies)}, Enter to cancel)'])
     if not raw or not raw.strip():
         return None
     try:

--- a/server/bar/bar_none.py
+++ b/server/bar/bar_none.py
@@ -604,7 +604,7 @@ async def main(ctx: GameContext, bar=None) -> None:
     if not player.is_expert:
         tip_lines = tip(ctx, "Mae the Bartender",
                         "Mae is the owner and bartender of 'Bar None.' "
-                        "You can (L)ist the menu at any time, or enter a number to buy something.")
+                        "You can [L]ist the menu at any time, or enter a number to buy something.")
         description_lines = []
         if tip_lines:
             description_lines.append("")

--- a/server/bar/bar_none.py
+++ b/server/bar/bar_none.py
@@ -91,7 +91,9 @@ async def _mae_session(ctx: GameContext, mae: Bartender) -> None:
     await broadcast_area(ctx, 'bar', f'{player.name} pulls up a stool at {mae.name}{_AP}s bar.')
 
     while True:
-        raw = await ctx.prompt(f"1-{len(displayed_items)}, [L]ist, [X]pert")
+        raw = await ctx.prompt(
+            'Choice',
+            preamble_lines=[f"1-{len(displayed_items)}, [L]ist, [X]pert"])
         if raw is None:
             await ctx.send(f'{mae.name} nods as you head for the door. "See you around."')
             break
@@ -270,7 +272,9 @@ async def _guss_flip(ctx: GameContext) -> None:
             await ctx.send('Guss says, "Yer too rich for me!"')
             return
 
-        raw = await ctx.prompt('"How much ya wanna bet?" (Enter to leave)')
+        raw = await ctx.prompt(
+            'Bet',
+            preamble_lines=['"How much ya wanna bet?" (Enter to leave)'])
         if raw is None or not raw.strip() or raw.strip().upper() == 'Q':
             return
 
@@ -291,7 +295,9 @@ async def _guss_flip(ctx: GameContext) -> None:
 
         # Call the toss
         while True:
-            raw2 = await ctx.prompt("Call it! [H]eads or [T]ails?")
+            raw2 = await ctx.prompt(
+                'H/T',
+                preamble_lines=["Call it! [H]eads or [T]ails?"])
             if raw2 is None:
                 # Carrier drop — refund and exit
                 player.subtract_silver(PlayerMoneyTypes.IN_HAND, -bet)
@@ -381,7 +387,9 @@ async def _guss_blackjack(ctx: GameContext) -> None:
             await ctx.send('Guss says, "Yer too rich for me!"')
             return
 
-        raw = await ctx.prompt('"How much ya wanna bet?" (Enter or Q to leave)')
+        raw = await ctx.prompt(
+            'Bet',
+            preamble_lines=['"How much ya wanna bet?" (Enter or Q to leave)'])
         if raw is None or raw.strip().upper() in ('', 'Q'):
             return
 
@@ -442,7 +450,9 @@ async def _guss_blackjack(ctx: GameContext) -> None:
                 f'Guss shows: {_fmt_hand(g_hand, hide_hole=True)}',
             ])
 
-            raw2 = await ctx.prompt('[H]it, [D]ouble, [S]tand')
+            raw2 = await ctx.prompt(
+                'Choice',
+                preamble_lines=['[H]it, [D]ouble, [S]tand'])
             if raw2 is None:
                 # Carrier drop — forfeit bet and exit
                 player.unsaved_changes = True

--- a/server/bar/bar_none.py
+++ b/server/bar/bar_none.py
@@ -389,7 +389,7 @@ async def _guss_blackjack(ctx: GameContext) -> None:
 
         raw = await ctx.prompt(
             'Bet',
-            preamble_lines=[f'"How much ya wanna bet?" ({player.return_key} or Q to leave)'])
+            preamble_lines=[f'"How much ya wanna bet?" ({player.return_key} or [Q] Leave)'])
         if raw is None or raw.strip().upper() in ('', 'Q'):
             return
 

--- a/server/bar/bar_none.py
+++ b/server/bar/bar_none.py
@@ -274,7 +274,7 @@ async def _guss_flip(ctx: GameContext) -> None:
 
         raw = await ctx.prompt(
             'Bet',
-            preamble_lines=['"How much ya wanna bet?" (Enter to leave)'])
+            preamble_lines=[f'"How much ya wanna bet?" ({player.return_key} to leave)'])
         if raw is None or not raw.strip() or raw.strip().upper() == 'Q':
             return
 
@@ -389,7 +389,7 @@ async def _guss_blackjack(ctx: GameContext) -> None:
 
         raw = await ctx.prompt(
             'Bet',
-            preamble_lines=['"How much ya wanna bet?" (Enter or Q to leave)'])
+            preamble_lines=[f'"How much ya wanna bet?" ({player.return_key} or Q to leave)'])
         if raw is None or raw.strip().upper() in ('', 'Q'):
             return
 

--- a/server/bar/blue_djinn.py
+++ b/server/bar/blue_djinn.py
@@ -182,7 +182,9 @@ async def _hire(ctx: GameContext) -> None:
     await ctx.send(f'{_NPC}: {_AP}Who do you wish me to mess up?{_AP}')
 
     while True:
-        raw = await ctx.prompt('Player name (? to list, Enter to cancel)')
+        raw = await ctx.prompt(
+            'Name',
+            preamble_lines=['Player name (? to list, Enter to cancel)'])
         if not raw or not raw.strip():
             return
 
@@ -226,7 +228,9 @@ async def _hire(ctx: GameContext) -> None:
                 lines.append(f'  {i:>3}.{star} {n}')
             lines.append('')
             await ctx.send(lines)
-            raw2 = await ctx.prompt(f'Choose (1–{len(names)}, Enter to cancel)')
+            raw2 = await ctx.prompt(
+                'Choice',
+                preamble_lines=[f'Choose (1–{len(names)}, Enter to cancel)'])
             if not raw2 or not raw2.strip():
                 return
             try:
@@ -276,7 +280,9 @@ async def _hire(ctx: GameContext) -> None:
             return
 
         # Anonymous option (SPUR.BAR.S: "Do you wish to remain unknown?")
-        raw5 = await ctx.prompt('Do you wish to remain unknown? (Y/N)')
+        raw5 = await ctx.prompt(
+            'Y/N',
+            preamble_lines=['Do you wish to remain unknown? (Y/N)'])
         if raw5 and raw5.strip().upper() == 'Y':
             attacker_display = 'SOMEBODY'
         else:

--- a/server/bar/blue_djinn.py
+++ b/server/bar/blue_djinn.py
@@ -184,7 +184,7 @@ async def _hire(ctx: GameContext) -> None:
     while True:
         raw = await ctx.prompt(
             'Name',
-            preamble_lines=['Player name (? to list, Enter to cancel)'])
+            preamble_lines=[f'Player name (? to list, {player.return_key} to cancel)'])
         if not raw or not raw.strip():
             return
 
@@ -230,7 +230,7 @@ async def _hire(ctx: GameContext) -> None:
             await ctx.send(lines)
             raw2 = await ctx.prompt(
                 'Choice',
-                preamble_lines=[f'Choose (1–{len(names)}, Enter to cancel)'])
+                preamble_lines=[f'Choose (1–{len(names)}, {player.return_key} to cancel)'])
             if not raw2 or not raw2.strip():
                 return
             try:

--- a/server/bar/fat_olaf.py
+++ b/server/bar/fat_olaf.py
@@ -177,7 +177,9 @@ async def _buy_servant(ctx: GameContext, master_list: List[Ally]) -> None:
                   '']
         await ctx.send(lines)
 
-        raw = await ctx.prompt(f'{_NPC}: {_AP}Buy vich vun? (1-{len(available)}, ? to list){_AP}')
+        raw = await ctx.prompt(
+            'Choice',
+            preamble_lines=[f'{_NPC}: {_AP}Buy vich vun? (1-{len(available)}, ? to list){_AP}'])
         if raw is None or raw.strip() == '':
             await ctx.send(f'{_NPC} dismisses you with a wave. {_AP}Hokay, vine. See yu later!{_AP}')
             return
@@ -204,9 +206,10 @@ async def _buy_servant(ctx: GameContext, master_list: List[Ally]) -> None:
 
         elite_line = f'(An Elite ally!)\n' if _is_elite(chosen) else ''
         raw2 = await ctx.prompt(
-            f'{elite_line}{_NPC}: {_AP}Vell, {chosen.name} iz a vine specimen — '
-            f'{price}s. Hokay?{_AP} (Y/N)'
-        )
+            'Y/N',
+            preamble_lines=[
+                f'{elite_line}{_NPC}: {_AP}Vell, {chosen.name} iz a vine specimen — '
+                f'{price}s. Hokay?{_AP} (Y/N)'])
         if not raw2 or raw2.strip().upper() != 'Y':
             await ctx.send(f'{_NPC}: {_AP}Vell, too bad!{_AP}')
             continue
@@ -284,9 +287,10 @@ async def _sell_servant(ctx: GameContext, master_list: List[Ally]) -> None:
 
     # Olaf makes his offer and asks for confirmation (SPUR.BAR.S)
     raw2 = await ctx.prompt(
-        f'{_NPC}: {_AP}He dun{_AP}t look teu gud, but I gus I cun give yu {offer}s. '
-        f'Hokay?{_AP} (Y/N)'
-    )
+        'Y/N',
+        preamble_lines=[
+            f'{_NPC}: {_AP}He dun{_AP}t look teu gud, but I gus I cun give yu {offer}s. '
+            f'Hokay?{_AP} (Y/N)'])
     if not raw2 or raw2.strip().upper() != 'Y':
         await ctx.send(f'{_NPC}: {_AP}Hoh vell.{_AP}')
         return
@@ -344,8 +348,8 @@ async def _maintain_servant(ctx: GameContext, master_list: List[Ally]) -> None:
     silver = player.get_silver(PlayerMoneyTypes.IN_HAND)
 
     raw2 = await ctx.prompt(
-        f'{_NPC}: {_AP}Dat vill be {cost}s. Yu hav {silver}s. Hokay?{_AP} (Y/N)'
-    )
+        'Y/N',
+        preamble_lines=[f'{_NPC}: {_AP}Dat vill be {cost}s. Yu hav {silver}s. Hokay?{_AP} (Y/N)'])
     if not raw2 or raw2.strip().upper() != 'Y':
         await ctx.send(f'{_NPC} shrugs.')
         return

--- a/server/bar/main.py
+++ b/server/bar/main.py
@@ -369,7 +369,7 @@ async def enter_bar(ctx: GameContext) -> None:
                 else:
                     move_into_obstacle = True
             else:
-                await ctx.send('Hm? (N/S/E/W to move, H for help, Q to leave)')
+                await ctx.send('Hm? (N/S/E/W to move, [H] Help, [Q] Leave)')
 
             if moved_direction:
                 await broadcast_area(ctx, 'bar',

--- a/server/bar/skip.py
+++ b/server/bar/skip.py
@@ -167,7 +167,9 @@ async def main(ctx: GameContext, bar=None) -> None:
 
                 selection = None
                 while True:
-                    raw_sel = await ctx.prompt(f'Choose (1-{len(patrons)})')
+                    raw_sel = await ctx.prompt(
+                        '#',
+                        preamble_lines=[f'Choose (1-{len(patrons)})'])
                     if raw_sel is None:
                         break
                     try:

--- a/server/bar/thug_attack.py
+++ b/server/bar/thug_attack.py
@@ -67,7 +67,9 @@ async def maybe_trigger_thug_attack(ctx: GameContext) -> None:
                      'set -- ambushing anyway', player.name)
 
     if player.query_flag(PlayerFlags.DEBUG_MODE):
-        raw = await ctx.prompt('[DEBUG] Thug Attack pending -- skip the ambush? (Y/N)')
+        raw = await ctx.prompt(
+            'Y/N',
+            preamble_lines=['[DEBUG] Thug Attack pending -- skip the ambush? (Y/N)'])
         if raw and raw.strip().lower().startswith('y'):
             await ctx.send('[DEBUG] Skipping thug ambush -- left pending for next login.')
             return

--- a/server/bar/vinny.py
+++ b/server/bar/vinny.py
@@ -155,7 +155,7 @@ async def _apply_loan(ctx: GameContext, hn: str, dl: str) -> None:
 
     raw = await ctx.prompt(
         'Amount',
-        preamble_lines=[f'How much? (1–{headroom:,}, Enter to cancel)'])
+        preamble_lines=[f'How much? (1–{headroom:,}, {player.return_key} to cancel)'])
     if not raw or not raw.strip():
         await ctx.send(f'{_NPC} looks offended. {_AP}What? Was it sometin{_AP} I said?{_AP}')
         return
@@ -225,7 +225,7 @@ async def _pay_loan(ctx: GameContext, hn: str, dl: str) -> None:
              f'  Loan outstanding: {loan:>8,}s',
              f'  Minimum payment : {min_pay:>8,}s',
              '',
-             f'  [Enter] to cancel  |  A = pay all  |  or enter an amount',
+             f'  [{player.return_key}] to cancel  |  A = pay all  |  or enter an amount',
              '']
     await ctx.send(lines)
 
@@ -306,7 +306,7 @@ async def _store_money(ctx: GameContext, dl: str) -> None:
              f'  Already stored  : {in_bar:>8,}s',
              f'  Can deposit max : {can_store:>8,}s',
              '',
-             f'  [Enter] to cancel  |  A = all  |  or enter an amount',
+             f'  [{player.return_key}] to cancel  |  A = all  |  or enter an amount',
              '']
     await ctx.send(lines)
 
@@ -347,7 +347,7 @@ async def _get_money(ctx: GameContext, dl: str) -> None:
     lines = ['',
              f'  Stored in bar   : {in_bar:>8,}s',
              '',
-             f'  [Enter] to cancel  |  A = all  |  or enter an amount',
+             f'  [{player.return_key}] to cancel  |  A = all  |  or enter an amount',
              '']
     await ctx.send(lines)
 

--- a/server/bar/vinny.py
+++ b/server/bar/vinny.py
@@ -154,8 +154,8 @@ async def _apply_loan(ctx: GameContext, hn: str, dl: str) -> None:
         )
 
     raw = await ctx.prompt(
-        f'How much? (1–{headroom:,}, Enter to cancel)'
-    )
+        'Amount',
+        preamble_lines=[f'How much? (1–{headroom:,}, Enter to cancel)'])
     if not raw or not raw.strip():
         await ctx.send(f'{_NPC} looks offended. {_AP}What? Was it sometin{_AP} I said?{_AP}')
         return
@@ -181,7 +181,9 @@ async def _apply_loan(ctx: GameContext, hn: str, dl: str) -> None:
         f'atta average of {daily:,}s a day, or else!{_AP}'
     )
 
-    raw2 = await ctx.prompt(f'Can youse handle dis, {hn}? (Y/N)')
+    raw2 = await ctx.prompt(
+        'Y/N',
+        preamble_lines=[f'Can youse handle dis, {hn}? (Y/N)'])
     if not raw2 or raw2.strip().upper() != 'Y':
         await ctx.send(f'{_NPC} smirks. {_AP}Hah. Thought not.{_AP}')
         return

--- a/server/bar/zelda.py
+++ b/server/bar/zelda.py
@@ -145,7 +145,9 @@ async def _study_player(ctx: GameContext) -> None:
     if not player.query_flag(PlayerFlags.EXPERT_MODE):
         await ctx.send('[?] lists players.  Wildcards * and ? are supported.')
 
-    raw = await ctx.prompt('"Study which player?" (? to list, wildcards ok)')
+    raw = await ctx.prompt(
+        'Name',
+        preamble_lines=['"Study which player?" (? to list, wildcards ok)'])
     if raw is None:
         return
     look_up = raw.strip()
@@ -291,7 +293,9 @@ async def _resurrect_monsters(ctx: GameContext) -> None:
     if not player.query_flag(PlayerFlags.EXPERT_MODE):
         await ctx.send('[?] lists players.  Wildcards * and ? are supported.')
 
-    raw = await ctx.prompt(f'{_NPC}: "Whooose monsters shall I briiiiing back to liiiiife?" (? to list)')
+    raw = await ctx.prompt(
+        'Name',
+        preamble_lines=[f'{_NPC}: "Whooose monsters shall I briiiiing back to liiiiife?" (? to list)'])
     if raw is None:
         return
     target = raw.strip()
@@ -343,7 +347,9 @@ async def _resurrect_monsters(ctx: GameContext) -> None:
         return
 
     # Anonymous option (SPUR.BAR.S: "Dooo you wish to be unknown?")
-    raw4 = await ctx.prompt(f'{_NPC}: "Dooo you wish to be unknown?" (Y/N)')
+    raw4 = await ctx.prompt(
+        'Y/N',
+        preamble_lines=[f'{_NPC}: "Dooo you wish to be unknown?" (Y/N)'])
     anonymous  = raw4 is not None and raw4.strip().upper() == 'Y'
     benefactor = 'SOMEBODY' if anonymous else player.name
 
@@ -471,7 +477,9 @@ async def main(ctx: GameContext, bar=None) -> None:
 
     while True:
         await ctx.send('')
-        raw = await ctx.prompt(f'{_NPC}: "What dooooo you wiiiiiish?"')
+        raw = await ctx.prompt(
+            'Choice',
+            preamble_lines=[f'{_NPC}: "What dooooo you wiiiiiish?"'])
         if raw is None:
             break
 

--- a/server/commands/board.py
+++ b/server/commands/board.py
@@ -98,7 +98,9 @@ async def prompt_reply_title(ctx, default_title: str) -> str | None:
     that way. Returns None if the player disconnected mid-prompt.
     Shared by this module's own _reply() and commands/board_reply.py's
     interactive reply flow."""
-    raw = await ctx.prompt(f'Enter title of reply, [{ctx.player.return_key} keeps same]')
+    raw = await ctx.prompt(
+        'Title',
+        preamble_lines=[f'Enter title of reply, [{ctx.player.return_key} keeps same]'])
     if raw is None:
         return None
     raw = raw.strip()

--- a/server/commands/board_edit.py
+++ b/server/commands/board_edit.py
@@ -62,7 +62,7 @@ async def edit_board_settings(ctx) -> CommandResult:
 
 
 async def _edit_anonymous_mode(ctx, config: dict) -> None:
-    raw = await ctx.prompt('[A]sk / [Y]es / [N]o')
+    raw = await ctx.prompt('Choice', preamble_lines=['[A]sk / [Y]es / [N]o'])
     choice = (raw or '').strip().lower()[:1]
     new_mode = _ANON_MODE_CHOICES.get(choice)
     if new_mode is None:

--- a/server/commands/cast.py
+++ b/server/commands/cast.py
@@ -455,7 +455,9 @@ class CastCommand(Command):
         await ctx.send(spell_list_lines(ctx))
 
         while True:
-            raw = await ctx.prompt('Cast which spell number? (?=list, Q to leave)')
+            raw = await ctx.prompt(
+                'Spell #',
+                preamble_lines=['Cast which spell number? (?=list, Q to leave)'])
             if raw is None:
                 return CommandResult.ok()
             choice = raw.strip()

--- a/server/commands/cast.py
+++ b/server/commands/cast.py
@@ -457,7 +457,7 @@ class CastCommand(Command):
         while True:
             raw = await ctx.prompt(
                 'Spell #',
-                preamble_lines=['Cast which spell number? (?=list, Q to leave)'])
+                preamble_lines=['Cast which spell number? (?=list, [Q] Leave)'])
             if raw is None:
                 return CommandResult.ok()
             choice = raw.strip()
@@ -471,7 +471,7 @@ class CastCommand(Command):
             try:
                 index = int(choice)
             except ValueError:
-                await ctx.send('Enter a spell number, ? to list, or Q to leave.')
+                await ctx.send('Enter a spell number, ? to list, or [Q] Leave.')
                 continue
             if index < 1 or index > len(entries):
                 await ctx.send('You do not know that spell.')

--- a/server/commands/config.py
+++ b/server/commands/config.py
@@ -75,7 +75,7 @@ async def _prompt_new_value(ctx, key: str, label: str, desc: str) -> None:
         hint = " Type '?' to list eligible items." if key == _VICTORY_ITEM_KEY else ''
         raw = await ctx.prompt(
             f'New value for {label}',
-            preamble_lines=['', desc, f'Current: {current}  —  blank to cancel{hint}'],
+            preamble_lines=['', desc, f'Current: {current}  —  {ctx.player.return_key} to cancel{hint}'],
         )
         if raw is None or not raw.strip():
             return

--- a/server/commands/edit.py
+++ b/server/commands/edit.py
@@ -213,7 +213,8 @@ class EditCommand(Command):
         data = load_recovery_file(recovery_path)
         label = data.get('activity_label') or 'writing something'
         choice = await ctx.prompt(
-            f'Before the server went down, you were {label}. Resume editing? y/n')
+            'y/n',
+            preamble_lines=[f'Before the server went down, you were {label}. Resume editing? y/n'])
         if not (choice or '').strip().lower().startswith('y'):
             delete_recovery_file(recovery_path)
             await ctx.send('Recovery text discarded.')

--- a/server/commands/editplayer.py
+++ b/server/commands/editplayer.py
@@ -131,7 +131,9 @@ class EditPlayerCommand(Command):
             target.client_settings = target_client_settings
 
         if getattr(target, 'unsaved_changes', False):
-            raw = await ctx.prompt(f'Save changes to {target.name}? (Y/N)')
+            raw = await ctx.prompt(
+                'Confirm',
+                preamble_lines=[f'Save changes to {target.name}? (Y/N)'])
             if raw and raw.strip().lower().startswith('y'):
                 target.save(force=True)
                 await ctx.send(f'Saved {target.name}.')
@@ -673,7 +675,9 @@ def _map_info_menu(ctx) -> Menu:
         if not getattr(p, 'visited_rooms', None):
             await ctx.send(f'{p.name} has no visited-rooms data to reset.')
             return
-        confirm = await ctx.prompt(f"Clear {p.name}'s visited-rooms history on all levels? (y/N)")
+        confirm = await ctx.prompt(
+            'Confirm',
+            preamble_lines=[f"Clear {p.name}'s visited-rooms history on all levels? (y/N)"])
         if not confirm or confirm.strip().lower() != 'y':
             await ctx.send('Cancelled.')
             return
@@ -1107,7 +1111,8 @@ def _names_menu(ctx) -> Menu:
         below via player.party.add().
         """
         raw = await ctx.prompt(
-            'No ally in that slot. Add one? (Y/N, or ? to list available allies)'
+            'Add ally',
+            preamble_lines=['No ally in that slot. Add one? (Y/N, or ? to list available allies)'],
         )
         if raw and raw.strip() == '?':
             pass  # fall through into pick_ally(), which lists then prompts
@@ -1421,7 +1426,8 @@ def _names_menu(ctx) -> Menu:
 
         while True:
             raw = await ctx.prompt(
-                "Ally name to add (or part of name, '?' to list all, blank to cancel)"
+                'Ally name',
+                preamble_lines=["Ally name to add (or part of name, '?' to list all, blank to cancel)"],
             )
             if raw and raw.strip() == '?':
                 await _send_labeled_list(ctx, 'Available allies', available, _roster_label)
@@ -1964,7 +1970,7 @@ def _statistics_menu(ctx) -> Menu:
                 lines = ['Monsters killed: (none)']
             await ctx.send(lines)
 
-            raw = await ctx.prompt('[A]dd  [R]emove  [Q]uit')
+            raw = await ctx.prompt('Command', preamble_lines=['[A]dd  [R]emove  [Q]uit'])
             if not raw or not raw.strip():
                 break
             cmd = raw.strip().lower()[:1]
@@ -1972,7 +1978,7 @@ def _statistics_menu(ctx) -> Menu:
             if cmd == 'q':
                 break
             elif cmd == 'a':
-                term_raw = await ctx.prompt('Monster name (or part of name)')
+                term_raw = await ctx.prompt('Monster name', preamble_lines=['Monster name (or part of name)'])
                 if not term_raw or not term_raw.strip():
                     continue
                 term    = term_raw.strip().lower()
@@ -1993,7 +1999,7 @@ def _statistics_menu(ctx) -> Menu:
                 if not killed:
                     await ctx.send('Nothing to remove.')
                     continue
-                idx_raw = await ctx.prompt(f'Remove which (1-{len(killed)})')
+                idx_raw = await ctx.prompt('#', preamble_lines=[f'Remove which (1-{len(killed)})'])
                 try:
                     idx = int((idx_raw or '').strip()) - 1
                     if not (0 <= idx < len(killed)):
@@ -2110,7 +2116,7 @@ async def _pick_from_matches(ctx, matches: list, label_fn) -> Optional[object]:
         lines.append(f'  {i:>2}. {label_fn(item)}')
     await ctx.send(lines)
 
-    raw = await ctx.prompt(f'Choose 1-{len(matches)}, or blank to cancel')
+    raw = await ctx.prompt('Choice', preamble_lines=[f'Choose 1-{len(matches)}, or blank to cancel'])
     if not raw or not raw.strip():
         return None
     try:
@@ -2282,7 +2288,7 @@ async def _transfer_item(ctx) -> None:
         return
 
     await _show_inventory(ctx)
-    raw = await ctx.prompt('Transfer which item # (blank to cancel)')
+    raw = await ctx.prompt('Item #', preamble_lines=['Transfer which item # (blank to cancel)'])
     if not raw or not raw.strip():
         return
     try:
@@ -2302,7 +2308,9 @@ async def _transfer_item(ctx) -> None:
         return
     recipient_name = recipient[1].name
 
-    confirm = await ctx.prompt(f'Transfer {item_name} to {recipient_name}? (y/N)')
+    confirm = await ctx.prompt(
+        'Confirm',
+        preamble_lines=[f'Transfer {item_name} to {recipient_name}? (y/N)'])
     if not confirm or confirm.strip().lower() != 'y':
         await ctx.send('Cancelled.')
         return
@@ -2350,7 +2358,7 @@ async def _drop_item(ctx) -> None:
         return
 
     await _show_inventory(ctx)
-    raw = await ctx.prompt('Drop which item # (blank to cancel)')
+    raw = await ctx.prompt('Item #', preamble_lines=['Drop which item # (blank to cancel)'])
     if not raw or not raw.strip():
         return
     try:
@@ -2364,7 +2372,9 @@ async def _drop_item(ctx) -> None:
     item = entry.item
     item_name = getattr(item, 'name', '?')
 
-    confirm = await ctx.prompt(f'Delete {item_name} from {ctx.player.name}? (y/N)')
+    confirm = await ctx.prompt(
+        'Confirm',
+        preamble_lines=[f'Delete {item_name} from {ctx.player.name}? (y/N)'])
     if not confirm or confirm.strip().lower() != 'y':
         await ctx.send('Cancelled.')
         return
@@ -2589,7 +2599,9 @@ async def _give_weapon(ctx) -> None:
         return
 
     while True:
-        raw = await ctx.prompt("Weapon name (or part of name, '?' to list all)")
+        raw = await ctx.prompt(
+            'Weapon name',
+            preamble_lines=["Weapon name (or part of name, '?' to list all)"])
         if raw and raw.strip() == '?':
             await _send_weapon_list(ctx, weapons)
             continue
@@ -2624,7 +2636,9 @@ async def _give_ration(ctx) -> None:
         return f'{r.get("name","?"):<24}  [{r.get("kind","?")}]'
 
     while True:
-        raw = await ctx.prompt("Ration name (or part of name, blank = show all, '?' to list all)")
+        raw = await ctx.prompt(
+            'Ration name',
+            preamble_lines=["Ration name (or part of name, blank = show all, '?' to list all)"])
         if raw and raw.strip() == '?':
             await _send_labeled_list(ctx, 'Rations', rations, _label)
             continue
@@ -2670,7 +2684,9 @@ async def _give_object(ctx, type_filter: set, label: str) -> None:
         return f'{o.get("name","?"):<28}  [{o.get("type","?")}]'
 
     while True:
-        raw = await ctx.prompt(f"{label.capitalize()} name (or part of name, '?' to list all)")
+        raw = await ctx.prompt(
+            f'{label.capitalize()} name',
+            preamble_lines=[f"{label.capitalize()} name (or part of name, '?' to list all)"])
         if raw and raw.strip() == '?':
             await _send_labeled_list(ctx, label.capitalize(), pool, _label)
             continue

--- a/server/commands/editplayer.py
+++ b/server/commands/editplayer.py
@@ -241,7 +241,7 @@ async def _prompt_int(ctx, label: str, current: int,
     while True:
         raw = await ctx.prompt(
             f'{label} [{lo}-{hi}]',
-            preamble_lines=[f'Current: {current}  —  blank to cancel'],
+            preamble_lines=[f'Current: {current}  —  {ctx.player.return_key} to cancel'],
         )
         if raw is None or not raw.strip():
             return None
@@ -268,7 +268,7 @@ async def _prompt_battle_exp_value(ctx, label: str, current: int,
             f'{label} battle experience',
             preamble_lines=[
                 f'Current: {current}  (enter {lo}-{hi}, or +N/-N to adjust)  '
-                '—  blank to cancel'
+                f'—  {ctx.player.return_key} to cancel'
             ],
         )
         if raw is None or not raw.strip():
@@ -611,7 +611,7 @@ def _map_info_menu(ctx) -> Menu:
                 'Room Number',
                 preamble_lines=[
                     f'Current: {_room_label(ctx, level, cur)}  —  '
-                    "blank to cancel, '?' to list rooms on this level"
+                    f"{ctx.player.return_key} to cancel, '?' to list rooms on this level"
                 ],
             )
             if raw is None or not raw.strip():
@@ -1266,7 +1266,7 @@ def _names_menu(ctx) -> Menu:
         gender/breed/colour and prompts for a name exactly like a real
         LASSO capture (ally_events/capture_horse.py's capture_mount()):
         same "Your horse seems to be..." announcement and the same
-        prompt_horse_name() (typed name, 'R' for random, blank to cancel).
+        prompt_horse_name() (typed name, 'R' for random, Enter to cancel).
         """
         import random
         from ally_events.capture_horse import prompt_horse_name
@@ -1427,7 +1427,7 @@ def _names_menu(ctx) -> Menu:
         while True:
             raw = await ctx.prompt(
                 'Ally name',
-                preamble_lines=["Ally name to add (or part of name, '?' to list all, blank to cancel)"],
+                preamble_lines=[f"Ally name to add (or part of name, '?' to list all, {ctx.player.return_key} to cancel)"],
             )
             if raw and raw.strip() == '?':
                 await _send_labeled_list(ctx, 'Available allies', available, _roster_label)
@@ -1568,7 +1568,7 @@ def _combinations_menu(ctx) -> Menu:
             preamble_lines=[
                 f'Current: {_fmt(combo_type)}',
                 'Enter three numbers like 04-05-09, R to randomize, X to '
-                'clear, or blank to cancel:',
+                f'clear, or {ctx.player.return_key} to cancel:',
             ],
         )
         if not raw or not raw.strip():
@@ -1935,7 +1935,7 @@ def _statistics_menu(ctx) -> Menu:
             'Defeated by',
             preamble_lines=[
                 f'Current: {cur or "(not set)"}',
-                "Type 'clear' to unset, blank to cancel:",
+                f"Type 'clear' to unset, {ctx.player.return_key} to cancel:",
             ],
         )
         if not raw or not raw.strip():
@@ -2116,7 +2116,7 @@ async def _pick_from_matches(ctx, matches: list, label_fn) -> Optional[object]:
         lines.append(f'  {i:>2}. {label_fn(item)}')
     await ctx.send(lines)
 
-    raw = await ctx.prompt('Choice', preamble_lines=[f'Choose 1-{len(matches)}, or blank to cancel'])
+    raw = await ctx.prompt('Choice', preamble_lines=[f'Choose 1-{len(matches)}, or {ctx.player.return_key} to cancel'])
     if not raw or not raw.strip():
         return None
     try:
@@ -2288,7 +2288,7 @@ async def _transfer_item(ctx) -> None:
         return
 
     await _show_inventory(ctx)
-    raw = await ctx.prompt('Item #', preamble_lines=['Transfer which item # (blank to cancel)'])
+    raw = await ctx.prompt('Item #', preamble_lines=[f'Transfer which item # ({ctx.player.return_key} to cancel)'])
     if not raw or not raw.strip():
         return
     try:
@@ -2358,7 +2358,7 @@ async def _drop_item(ctx) -> None:
         return
 
     await _show_inventory(ctx)
-    raw = await ctx.prompt('Item #', preamble_lines=['Drop which item # (blank to cancel)'])
+    raw = await ctx.prompt('Item #', preamble_lines=[f'Drop which item # ({ctx.player.return_key} to cancel)'])
     if not raw or not raw.strip():
         return
     try:

--- a/server/commands/editplayer.py
+++ b/server/commands/editplayer.py
@@ -1567,8 +1567,8 @@ def _combinations_menu(ctx) -> Menu:
             f'{combo_type.value} (xx-xx-xx)',
             preamble_lines=[
                 f'Current: {_fmt(combo_type)}',
-                'Enter three numbers like 04-05-09, [R]andomize, X to '
-                f'clear, or {ctx.player.return_key} to cancel:',
+                'Enter three numbers like 04-05-09, [R]andomize, [X] Clear, '
+                f'or {ctx.player.return_key} to cancel:',
             ],
         )
         if not raw or not raw.strip():

--- a/server/commands/editplayer.py
+++ b/server/commands/editplayer.py
@@ -1567,7 +1567,7 @@ def _combinations_menu(ctx) -> Menu:
             f'{combo_type.value} (xx-xx-xx)',
             preamble_lines=[
                 f'Current: {_fmt(combo_type)}',
-                'Enter three numbers like 04-05-09, R to randomize, X to '
+                'Enter three numbers like 04-05-09, [R]andomize, X to '
                 f'clear, or {ctx.player.return_key} to cancel:',
             ],
         )

--- a/server/commands/list_locations.py
+++ b/server/commands/list_locations.py
@@ -255,7 +255,8 @@ class ListLocationsCommand(Command):
     async def _offer_teleport(self, ctx: GameContext, found: list) -> None:
         return_key = ctx.player.return_key
         raw_choice = await ctx.prompt(
-            f'Teleport to which number? (or {return_key} to abort)'
+            '#',
+            preamble_lines=[f'Teleport to which number? (or {return_key} to abort)'],
         )
         if not raw_choice or not raw_choice.strip():
             return

--- a/server/commands/logs.py
+++ b/server/commands/logs.py
@@ -217,10 +217,10 @@ class LogsCommand(Command):
         return CommandResult.ok()
 
     async def _choose_filters(self, ctx: GameContext, source: str) -> tuple[str | None, str | None]:
-        player_filter = await self._prompt_optional(ctx, 'Filter by player (Enter for all)')
+        player_filter = await self._prompt_optional(ctx, f'Filter by player ({ctx.player.return_key} for all)')
         module_filter = None
         if source == 'system':
-            module_filter = await self._prompt_optional(ctx, 'Filter by module (Enter for all)')
+            module_filter = await self._prompt_optional(ctx, f'Filter by module ({ctx.player.return_key} for all)')
         return player_filter, module_filter
 
     async def _prompt_optional(self, ctx: GameContext, message: str) -> str | None:

--- a/server/commands/logs.py
+++ b/server/commands/logs.py
@@ -235,7 +235,7 @@ class LogsCommand(Command):
 
         raw = await ctx.prompt(
             'Log #',
-            preamble_lines=[f'View which log? (1-{len(_SOURCE_ORDER)}, blank to cancel)'])
+            preamble_lines=[f'View which log? (1-{len(_SOURCE_ORDER)}, {ctx.player.return_key} to cancel)'])
         if not raw or not raw.strip():
             return None
         choice = raw.strip().lower()

--- a/server/commands/logs.py
+++ b/server/commands/logs.py
@@ -224,7 +224,7 @@ class LogsCommand(Command):
         return player_filter, module_filter
 
     async def _prompt_optional(self, ctx: GameContext, message: str) -> str | None:
-        raw = await ctx.prompt(message)
+        raw = await ctx.prompt('Filter', preamble_lines=[message])
         return raw.strip() if raw and raw.strip() else None
 
     async def _choose_source(self, ctx: GameContext) -> str | None:
@@ -233,7 +233,9 @@ class LogsCommand(Command):
             lines.append(f'{i}. {_SOURCE_LABELS[key]}')
         await ctx.send(lines)
 
-        raw = await ctx.prompt(f'View which log? (1-{len(_SOURCE_ORDER)}, blank to cancel)')
+        raw = await ctx.prompt(
+            'Log #',
+            preamble_lines=[f'View which log? (1-{len(_SOURCE_ORDER)}, blank to cancel)'])
         if not raw or not raw.strip():
             return None
         choice = raw.strip().lower()

--- a/server/commands/loot.py
+++ b/server/commands/loot.py
@@ -163,7 +163,9 @@ class LootCommand(Command):
         lines.append('')
         await ctx.send(lines)
 
-        raw = await ctx.prompt(f'Loot which Adventurer (1-{len(mates)}, {player.return_key} to abort)')
+        raw = await ctx.prompt(
+            'Adventurer #',
+            preamble_lines=[f'Loot which Adventurer (1-{len(mates)}, {player.return_key} to abort)'])
         if not raw or not raw.strip():
             return CommandResult.ok()
         try:
@@ -202,7 +204,9 @@ class LootCommand(Command):
         lines.append('')
         await ctx.send(lines)
 
-        raw = await ctx.prompt(f'Take which item number? (1-{len(target_entries)}, {player.return_key} to abort)')
+        raw = await ctx.prompt(
+            'Item #',
+            preamble_lines=[f'Take which item number? (1-{len(target_entries)}, {player.return_key} to abort)'])
         if not raw or not raw.strip():
             return CommandResult.ok()
         try:

--- a/server/commands/mail.py
+++ b/server/commands/mail.py
@@ -191,8 +191,9 @@ class MailCommand(Command):
                     return CommandResult.ok('No mail.')
 
                 raw = await ctx.prompt(
-                    f"Read which (#, 'd<n>' to delete, or {ctx.player.return_key} to exit)",
-                    preamble_lines=self._render_listing(ctx, [m for _, m in entries]),
+                    '#',
+                    preamble_lines=self._render_listing(ctx, [m for _, m in entries])
+                    + [f"Read which (#, 'd<n>' to delete, or {ctx.player.return_key} to exit)"],
                 )
                 if raw is None or not raw.strip():
                     return CommandResult.ok('Exited mail.')
@@ -336,8 +337,11 @@ class MailCommand(Command):
                 )
 
                 raw = await ctx.prompt(
-                    f'[R]eply, [D]elete, [A]rchive, [K]eep, Read [O]ver, '
-                    f'or {ctx.player.return_key} for next',
+                    'Choice',
+                    preamble_lines=[
+                        f'[R]eply, [D]elete, [A]rchive, [K]eep, Read [O]ver, '
+                        f'or {ctx.player.return_key} for next',
+                    ],
                 )
                 if raw is None:
                     return CommandResult.ok('Exited mail.')

--- a/server/commands/messaging.py
+++ b/server/commands/messaging.py
@@ -194,7 +194,9 @@ async def prompt_player_choice(ctx, pattern: str = '*', *,
     lines.append('')
     await ctx.send(lines)
 
-    raw = await ctx.prompt(f'{prompt_text} (number or name, {ctx.player.client_settings.return_key} to cancel)')
+    raw = await ctx.prompt(
+        prompt_text,
+        preamble_lines=[f'(number or name, {ctx.player.client_settings.return_key} to cancel)'])
     if not raw:
         return None
     raw = raw.strip()

--- a/server/commands/more_prompt.py
+++ b/server/commands/more_prompt.py
@@ -21,7 +21,7 @@ class MorePromptCommand(Command):
         description = (
             "When More Prompt is on, output longer than a screenful pauses "
             f"with a '-- More --' prompt between pages (Enter for next, "
-            "B/- for back, Q to stop). When off, everything is sent at "
+            "B/- for back, [Q] Stop). When off, everything is sent at "
             "once regardless of length. Same setting as 'prefs' menu's "
             "'M' key -- this is just a shortcut."
         ),

--- a/server/commands/new_player.py
+++ b/server/commands/new_player.py
@@ -512,7 +512,7 @@ async def _choose_username(ctx, prefill: Optional[str] = None,
                 "<http://www.commodoreserver.com> and has no bearing on "
                 "gameplay yet.)"]
     if default_username:
-        preamble.append(f"Press Enter to use '{default_username}'.")
+        preamble.append(f"Press {ctx.player.return_key} to use '{default_username}'.")
     preamble.append("")
 
     # TODO: capture this from CommodoreServer account name
@@ -1433,7 +1433,7 @@ async def _final_review(ctx) -> bool:
         if fn:
             await fn(ctx)   # re-run that step; loop back to summary afterwards
         else:
-            await ctx.send(f"Enter a number 1–{len(dispatch)}, or press Enter to accept.")
+            await ctx.send(f"Enter a number 1–{len(dispatch)}, or press {ctx.player.return_key} to accept.")
 
 
 # ---------------------------------------------------------------------------

--- a/server/commands/new_player.py
+++ b/server/commands/new_player.py
@@ -132,9 +132,9 @@ async def _confirm_quit_or_continue(ctx) -> None:
     """
     can_resume = bool(getattr(ctx.player, 'id', None))
     if can_resume:
-        options, label = "(A)bandon, (R)esume later, or (C)ontinue (don't quit)?", "A/R/C"
+        options, label = "[A]bandon, [R]esume later, or [C]ontinue (don't quit)?", "A/R/C"
     else:
-        options = ("(A)bandon, or (C)ontinue (don't quit)? (Resuming later isn't "
+        options = ("[A]bandon, or [C]ontinue (don't quit)? (Resuming later isn't "
                    "possible yet -- a username hasn't been chosen.)")
         label = "A/C"
     choice = await ctx.prompt(label, preamble_lines=['', f"Do you want to {options}"])

--- a/server/commands/new_player.py
+++ b/server/commands/new_player.py
@@ -594,7 +594,7 @@ async def _choose_password(ctx, prefill: Optional[str] = None) -> Optional[str]:
             "Choose a password",
             preamble_lines=[
                 "",
-                "Choose a password, or 'R' for a random pronounceable one.",
+                "Choose a password, or [R]andom for a pronounceable one.",
             ],
         )
         if pw1 is None:
@@ -664,7 +664,7 @@ async def _choose_age(ctx) -> bool:
     preamble = [
         "",
         "How old is your character?",
-        "Enter a number (15–50), or 'R' for a random age:",
+        "Enter a number (15–50), or [R]andom age:",
     ]
     while True:
         raw = await _prompt_or_quit(ctx, "age", preamble_lines=preamble)
@@ -683,7 +683,7 @@ async def _choose_age(ctx) -> bool:
                     break
         elif ans.isdigit():
             age = int(ans)
-            help_msg = "Please enter a number between 15 and 50, or 'R' to choose a random age."
+            help_msg = "Please enter a number between 15 and 50, or [R]andom to choose an age."
             if age < 15:
                 apostrophe = "'"
                 await ctx.send(f'"Oh, come off it! You{apostrophe}re not even old enough to handle a '
@@ -1211,7 +1211,7 @@ async def _roll_stats(ctx) -> bool:
             return True
         if ans in ("r", "reroll", "re-roll"):
             continue
-        await ctx.send("Enter 'Y' to accept or 'R' to re-roll.")
+        await ctx.send("Enter [Y] to accept or [R]e-roll.")
 
 
 async def _assign_equipment(ctx) -> bool:

--- a/server/commands/news.py
+++ b/server/commands/news.py
@@ -319,7 +319,7 @@ class NewsCommand(Command):
     async def _pick_lifetime(self, ctx, allow_skip: bool = False) -> dict | None:
         from parse_date import parse_date_range
 
-        prompt_extra = ' (or Enter to keep current)' if allow_skip else ''
+        prompt_extra = f' (or {ctx.player.return_key} to keep current)' if allow_skip else ''
         raw = await ctx.prompt(
             'Lifetime',
             preamble_lines=[

--- a/server/commands/news.py
+++ b/server/commands/news.py
@@ -120,8 +120,8 @@ class NewsCommand(Command):
                 lines.append('')
 
                 raw = await ctx.prompt(
-                    f'Read which (# or {ctx.player.return_key} to exit)',
-                    preamble_lines=lines,
+                    '#',
+                    preamble_lines=lines + [f'Read which (# or {ctx.player.return_key} to exit)'],
                 )
                 if raw is None or not raw.strip():
                     return CommandResult.ok('Exited news.')
@@ -298,9 +298,12 @@ class NewsCommand(Command):
                 return title
 
             raw = await ctx.prompt(
-                f"A news item titled '{existing.get('title', '')}' already exists "
-                f"(#{existing['id']}). [E]dit it, [C]hange this title, or "
-                f"{ctx.player.return_key} to abort",
+                'Choice',
+                preamble_lines=[
+                    f"A news item titled '{existing.get('title', '')}' already exists "
+                    f"(#{existing['id']}). [E]dit it, [C]hange this title, or "
+                    f"{ctx.player.return_key} to abort",
+                ],
             )
             choice = (raw or '').strip().lower()[:1]
             if choice == 'e':

--- a/server/commands/order.py
+++ b/server/commands/order.py
@@ -84,7 +84,7 @@ class OrderCommand(Command):
 
         await self._show_deployment(ctx, allies)
 
-        raw = await ctx.prompt('Do you wish to change this? Y/N')
+        raw = await ctx.prompt('Y/N', preamble_lines=['Do you wish to change this? Y/N'])
         if not raw or raw.strip().upper() != 'Y':
             return CommandResult.ok()
 
@@ -134,7 +134,9 @@ class OrderCommand(Command):
             lines.append(f'  {i}. {a.name}')
         await ctx.send(lines)
 
-        raw = await ctx.prompt(f'New {prompt_label} (1-{len(remaining)}, 0 for none)')
+        raw = await ctx.prompt(
+            f'New {prompt_label}',
+            preamble_lines=[f'New {prompt_label} (1-{len(remaining)}, 0 for none)'])
         if not raw or not raw.strip() or raw.strip() == '0':
             return None
         try:

--- a/server/commands/page.py
+++ b/server/commands/page.py
@@ -229,7 +229,9 @@ class PageCommand(Command):
             return
 
         await ctx.send(f'{name} is not online.')
-        raw = await ctx.prompt(f'Leave this as a mail message for {name}? (y/N)')
+        raw = await ctx.prompt(
+            'Confirm',
+            preamble_lines=[f'Leave this as a mail message for {name}? (y/N)'])
         if not raw or raw.strip().lower() not in ('y', 'yes'):
             return
 

--- a/server/commands/prefs.py
+++ b/server/commands/prefs.py
@@ -1131,7 +1131,9 @@ async def _pick_client_type(ctx) -> None:
                         f'{translation.name} translation.')
         return
 
-    raw_trans = await ctx.prompt('PETSCII, ANSI color, or Plain text? (T/A/P)')
+    raw_trans = await ctx.prompt(
+        'T/A/P',
+        preamble_lines=['PETSCII, ANSI color, or Plain text? (T/A/P)'])
     ans_trans = (raw_trans or '').strip().lower()
     if ans_trans.startswith('t'):
         translation = Translation.PETSCII

--- a/server/commands/prefs.py
+++ b/server/commands/prefs.py
@@ -90,7 +90,7 @@ _SETTING_HELP: dict[str, list[str]] = {
         '|cyan|More Prompt|reset|',
         "When output would be longer than one screen, pauses with a "
         "'-- More --' prompt between pages: Enter for the next page, "
-        "B or - to go back a page, Q to stop reading early. When off, "
+        "B or - to go back a page, [Q] Stop reading early. When off, "
         "everything is sent at once and scrolls by regardless of length. "
         "Same setting as the standalone 'mp' command.",
         '',

--- a/server/commands/quote.py
+++ b/server/commands/quote.py
@@ -65,7 +65,7 @@ class QuoteCommand(Command):
         player = ctx.player
 
         while True:
-            raw = await ctx.prompt('Choice', preamble_lines=['Quote: V)iew W)rite Q)uit'])
+            raw = await ctx.prompt('Choice', preamble_lines=['Quote: [V]iew [W]rite [Q]uit'])
             if raw is None:
                 return CommandResult.ok()
             ans = raw.strip().lower()

--- a/server/commands/quote.py
+++ b/server/commands/quote.py
@@ -65,7 +65,7 @@ class QuoteCommand(Command):
         player = ctx.player
 
         while True:
-            raw = await ctx.prompt('Quote: V)iew W)rite Q)uit')
+            raw = await ctx.prompt('Choice', preamble_lines=['Quote: V)iew W)rite Q)uit'])
             if raw is None:
                 return CommandResult.ok()
             ans = raw.strip().lower()

--- a/server/commands/read.py
+++ b/server/commands/read.py
@@ -145,11 +145,15 @@ async def _read_scrap_of_paper(ctx: GameContext, player) -> None:
 
     existing = combos.get(CombinationTypes.ELEVATOR)
     if existing is None:
-        raw = await ctx.prompt("A voice whispers, 'Art thou true of heart?' [Y/N]")
+        raw = await ctx.prompt(
+            'Y/N',
+            preamble_lines=["A voice whispers, 'Art thou true of heart?' [Y/N]"])
         # SPUR doesn't branch on the answer -- it's flavor only.
         _ = raw
 
-        raw = await ctx.prompt("'Wilt thou use this information for Good or Evil?' [G/E]")
+        raw = await ctx.prompt(
+            'G/E',
+            preamble_lines=["'Wilt thou use this information for Good or Evil?' [G/E]"])
         if (raw or '').strip().upper().startswith('E'):
             honor = int(getattr(player, 'honor', 0) or 0)
             if honor > 2:

--- a/server/date_cursor.py
+++ b/server/date_cursor.py
@@ -124,7 +124,7 @@ async def prompt_date_cursor(
         f'New {label}',
         preamble_lines=['', f'Current: {cur_str}', '', OFFSET_HELP, '',
                         RELATIVE_DATE_HELP, '', DATE_HELP, '',
-                        "'clear' to unset, blank to cancel:"],
+                        f"'clear' to unset, {player.return_key} to cancel:"],
     )
     if raw is None or not raw.strip():
         await ctx.send('Unchanged.')

--- a/server/encounters/gollum.py
+++ b/server/encounters/gollum.py
@@ -194,7 +194,9 @@ async def ask_riddle_menu(ctx) -> None:
     lines += numbered_list([riddle['text'] for riddle in _RIDDLES], width)
     await ctx.send(lines)
 
-    raw = await ctx.prompt(f'Riddle # ({ctx.player.return_key} to cancel)')
+    raw = await ctx.prompt(
+        'Riddle #',
+        preamble_lines=[f'Riddle # ({ctx.player.return_key} to cancel)'])
     try:
         choice = int((raw or '').strip())
     except ValueError:

--- a/server/encounters/little_girl.py
+++ b/server/encounters/little_girl.py
@@ -150,7 +150,7 @@ async def try_encounter(ctx: 'GameContext') -> None:
     await ctx.send_room(f'A little girl approaches {name}.', exclude_self=True)
 
     while True:
-        raw = await ctx.prompt('G)ive, I)gnore, A)ttack')
+        raw = await ctx.prompt('Choice', preamble_lines=['G)ive, I)gnore, A)ttack'])
         choice = (raw or '').strip().upper()[:1]
         if choice == 'G':
             await _handle_give(ctx)
@@ -236,7 +236,9 @@ async def _handle_give(ctx: 'GameContext') -> None:
         lines.append(f'  {i:>2}. {getattr(entry.item, "name", "?")}')
     await ctx.send(lines)
 
-    raw = await ctx.prompt(f'Give which item? (1-{len(entries)}, Enter to cancel)')
+    raw = await ctx.prompt(
+        'Item #',
+        preamble_lines=[f'Give which item? (1-{len(entries)}, Enter to cancel)'])
     if not raw or not raw.strip():
         return
     try:

--- a/server/encounters/little_girl.py
+++ b/server/encounters/little_girl.py
@@ -150,7 +150,7 @@ async def try_encounter(ctx: 'GameContext') -> None:
     await ctx.send_room(f'A little girl approaches {name}.', exclude_self=True)
 
     while True:
-        raw = await ctx.prompt('Choice', preamble_lines=['G)ive, I)gnore, A)ttack'])
+        raw = await ctx.prompt('Choice', preamble_lines=['[G]ive, [I]gnore, [A]ttack'])
         choice = (raw or '').strip().upper()[:1]
         if choice == 'G':
             await _handle_give(ctx)
@@ -161,7 +161,7 @@ async def try_encounter(ctx: 'GameContext') -> None:
         if choice == 'A':
             await _handle_attack(ctx)
             return
-        await ctx.send('Please choose G)ive, I)gnore, or A)ttack.')
+        await ctx.send('Please choose [G]ive, [I]gnore, or [A]ttack.')
 
 
 async def _reveal_and_attack(ctx: 'GameContext') -> None:

--- a/server/encounters/little_girl.py
+++ b/server/encounters/little_girl.py
@@ -238,7 +238,7 @@ async def _handle_give(ctx: 'GameContext') -> None:
 
     raw = await ctx.prompt(
         'Item #',
-        preamble_lines=[f'Give which item? (1-{len(entries)}, Enter to cancel)'])
+        preamble_lines=[f'Give which item? (1-{len(entries)}, {ctx.player.return_key} to cancel)'])
     if not raw or not raw.strip():
         return
     try:

--- a/server/guild_hq/main.py
+++ b/server/guild_hq/main.py
@@ -104,7 +104,7 @@ async def _food_locker(ctx: GameContext, player, state: dict, info: dict) -> Non
     await ctx.send('Lurch takes you to the food locker..')
 
     while True:
-        raw = await ctx.prompt('G)ive or T)ake food? (Q to leave)')
+        raw = await ctx.prompt('Choice', preamble_lines=['G)ive or T)ake food? (Q to leave)'])
         if raw is None:
             return
         cmd = raw.strip().upper()[:1]
@@ -129,7 +129,9 @@ async def _food_locker(ctx: GameContext, player, state: dict, info: dict) -> Non
             lines.append('')
             await ctx.send(lines)
 
-            raw = await ctx.prompt('Give which ration number? (Q to cancel)')
+            raw = await ctx.prompt(
+                '#',
+                preamble_lines=['Give which ration number? (Q to cancel)'])
             if raw is None:
                 return
             choice = raw.strip().upper()
@@ -172,7 +174,9 @@ async def _food_locker(ctx: GameContext, player, state: dict, info: dict) -> Non
             lines.append('')
             await ctx.send(lines)
 
-            raw = await ctx.prompt('Take which food number? (Q to cancel)')
+            raw = await ctx.prompt(
+                '#',
+                preamble_lines=['Take which food number? (Q to cancel)'])
             if raw is None:
                 return
             choice = raw.strip().upper()
@@ -218,7 +222,9 @@ async def _item_locker(ctx: GameContext, player, state: dict, info: dict) -> Non
     await ctx.send('Lurch shows you to the Items room..')
 
     while True:
-        raw = await ctx.prompt('G)ive or T)ake item? (Q to leave)')
+        raw = await ctx.prompt(
+            'Choice',
+            preamble_lines=['G)ive or T)ake item? (Q to leave)'])
         if raw is None:
             return
         cmd = raw.strip().upper()[:1]
@@ -241,7 +247,9 @@ async def _item_locker(ctx: GameContext, player, state: dict, info: dict) -> Non
             lines.append('')
             await ctx.send(lines)
 
-            raw = await ctx.prompt('Give which item number? (Q to cancel)')
+            raw = await ctx.prompt(
+                '#',
+                preamble_lines=['Give which item number? (Q to cancel)'])
             if raw is None:
                 return
             choice = raw.strip().upper()
@@ -289,7 +297,9 @@ async def _item_locker(ctx: GameContext, player, state: dict, info: dict) -> Non
             lines.append('')
             await ctx.send(lines)
 
-            raw = await ctx.prompt('Take which item number? (Q to cancel)')
+            raw = await ctx.prompt(
+                '#',
+                preamble_lines=['Take which item number? (Q to cancel)'])
             if raw is None:
                 return
             choice = raw.strip().upper()
@@ -342,7 +352,9 @@ async def _guild_bank(ctx: GameContext, player, state: dict, info: dict) -> None
             '',
         ])
 
-        raw = await ctx.prompt('R)eview, P)ay, T)ake, or Q to leave')
+        raw = await ctx.prompt(
+            'Choice',
+            preamble_lines=['R)eview, P)ay, T)ake, or Q to leave'])
         if raw is None:
             return
         cmd = raw.strip().upper()[:1]
@@ -524,7 +536,9 @@ async def _weapons_box(ctx: GameContext, player, state: dict, info: dict) -> Non
         return
 
     # Box is empty — offer to deposit a weapon
-    raw = await ctx.prompt('The box is empty. Put in a weapon? y/[N]')
+    raw = await ctx.prompt(
+        'Y/N',
+        preamble_lines=['The box is empty. Put in a weapon? y/[N]'])
     if raw is None or raw.strip().upper() != 'Y':
         return
 

--- a/server/guild_hq/main.py
+++ b/server/guild_hq/main.py
@@ -104,7 +104,7 @@ async def _food_locker(ctx: GameContext, player, state: dict, info: dict) -> Non
     await ctx.send('Lurch takes you to the food locker..')
 
     while True:
-        raw = await ctx.prompt('Choice', preamble_lines=['[G]ive or [T]ake food? (Q to leave)'])
+        raw = await ctx.prompt('Choice', preamble_lines=['[G]ive or [T]ake food? ([Q] Leave)'])
         if raw is None:
             return
         cmd = raw.strip().upper()[:1]
@@ -131,7 +131,7 @@ async def _food_locker(ctx: GameContext, player, state: dict, info: dict) -> Non
 
             raw = await ctx.prompt(
                 '#',
-                preamble_lines=['Give which ration number? (Q to cancel)'])
+                preamble_lines=['Give which ration number? ([Q] Cancel)'])
             if raw is None:
                 return
             choice = raw.strip().upper()
@@ -176,7 +176,7 @@ async def _food_locker(ctx: GameContext, player, state: dict, info: dict) -> Non
 
             raw = await ctx.prompt(
                 '#',
-                preamble_lines=['Take which food number? (Q to cancel)'])
+                preamble_lines=['Take which food number? ([Q] Cancel)'])
             if raw is None:
                 return
             choice = raw.strip().upper()
@@ -207,7 +207,7 @@ async def _food_locker(ctx: GameContext, player, state: dict, info: dict) -> Non
                 state['food_locker'].insert(idx, it)
                 await ctx.send('Your pack is full.')
         else:
-            await ctx.send('[G]ive or [T]ake food? (Q to leave)')
+            await ctx.send('[G]ive or [T]ake food? ([Q] Leave)')
 
 
 # ---------------------------------------------------------------------------
@@ -224,7 +224,7 @@ async def _item_locker(ctx: GameContext, player, state: dict, info: dict) -> Non
     while True:
         raw = await ctx.prompt(
             'Choice',
-            preamble_lines=['[G]ive or [T]ake item? (Q to leave)'])
+            preamble_lines=['[G]ive or [T]ake item? ([Q] Leave)'])
         if raw is None:
             return
         cmd = raw.strip().upper()[:1]
@@ -249,7 +249,7 @@ async def _item_locker(ctx: GameContext, player, state: dict, info: dict) -> Non
 
             raw = await ctx.prompt(
                 '#',
-                preamble_lines=['Give which item number? (Q to cancel)'])
+                preamble_lines=['Give which item number? ([Q] Cancel)'])
             if raw is None:
                 return
             choice = raw.strip().upper()
@@ -299,7 +299,7 @@ async def _item_locker(ctx: GameContext, player, state: dict, info: dict) -> Non
 
             raw = await ctx.prompt(
                 '#',
-                preamble_lines=['Take which item number? (Q to cancel)'])
+                preamble_lines=['Take which item number? ([Q] Cancel)'])
             if raw is None:
                 return
             choice = raw.strip().upper()
@@ -329,7 +329,7 @@ async def _item_locker(ctx: GameContext, player, state: dict, info: dict) -> Non
                 state['item_locker'].insert(idx, it)
                 await ctx.send('Your pack is full.')
         else:
-            await ctx.send('[G]ive or [T]ake item? (Q to leave)')
+            await ctx.send('[G]ive or [T]ake item? ([Q] Leave)')
 
 
 # ---------------------------------------------------------------------------
@@ -354,7 +354,7 @@ async def _guild_bank(ctx: GameContext, player, state: dict, info: dict) -> None
 
         raw = await ctx.prompt(
             'Choice',
-            preamble_lines=['[R]eview, [P]ay, [T]ake, or Q to leave'])
+            preamble_lines=['[R]eview, [P]ay, [T]ake, or [Q] Leave'])
         if raw is None:
             return
         cmd = raw.strip().upper()[:1]
@@ -409,7 +409,7 @@ async def _guild_bank(ctx: GameContext, player, state: dict, info: dict) -> None
             await ctx.send('Lurch hands it to you.')
 
         else:
-            await ctx.send('[R]eview, [P]ay, [T]ake, or Q to leave.')
+            await ctx.send('[R]eview, [P]ay, [T]ake, or [Q] Leave.')
 
 
 # ---------------------------------------------------------------------------
@@ -554,7 +554,7 @@ async def _weapons_box(ctx: GameContext, player, state: dict, info: dict) -> Non
     await ctx.send(lines)
 
     while True:
-        raw = await ctx.prompt('Which (Q to cancel)')
+        raw = await ctx.prompt('Which ([Q] Cancel)')
         if raw is None or raw.strip().upper() == 'Q':
             return
         try:

--- a/server/guild_hq/main.py
+++ b/server/guild_hq/main.py
@@ -104,7 +104,7 @@ async def _food_locker(ctx: GameContext, player, state: dict, info: dict) -> Non
     await ctx.send('Lurch takes you to the food locker..')
 
     while True:
-        raw = await ctx.prompt('Choice', preamble_lines=['G)ive or T)ake food? (Q to leave)'])
+        raw = await ctx.prompt('Choice', preamble_lines=['[G]ive or [T]ake food? (Q to leave)'])
         if raw is None:
             return
         cmd = raw.strip().upper()[:1]
@@ -207,7 +207,7 @@ async def _food_locker(ctx: GameContext, player, state: dict, info: dict) -> Non
                 state['food_locker'].insert(idx, it)
                 await ctx.send('Your pack is full.')
         else:
-            await ctx.send('G)ive or T)ake food? (Q to leave)')
+            await ctx.send('[G]ive or [T]ake food? (Q to leave)')
 
 
 # ---------------------------------------------------------------------------
@@ -224,7 +224,7 @@ async def _item_locker(ctx: GameContext, player, state: dict, info: dict) -> Non
     while True:
         raw = await ctx.prompt(
             'Choice',
-            preamble_lines=['G)ive or T)ake item? (Q to leave)'])
+            preamble_lines=['[G]ive or [T]ake item? (Q to leave)'])
         if raw is None:
             return
         cmd = raw.strip().upper()[:1]
@@ -329,7 +329,7 @@ async def _item_locker(ctx: GameContext, player, state: dict, info: dict) -> Non
                 state['item_locker'].insert(idx, it)
                 await ctx.send('Your pack is full.')
         else:
-            await ctx.send('G)ive or T)ake item? (Q to leave)')
+            await ctx.send('[G]ive or [T]ake item? (Q to leave)')
 
 
 # ---------------------------------------------------------------------------
@@ -354,7 +354,7 @@ async def _guild_bank(ctx: GameContext, player, state: dict, info: dict) -> None
 
         raw = await ctx.prompt(
             'Choice',
-            preamble_lines=['R)eview, P)ay, T)ake, or Q to leave'])
+            preamble_lines=['[R]eview, [P]ay, [T]ake, or Q to leave'])
         if raw is None:
             return
         cmd = raw.strip().upper()[:1]
@@ -409,7 +409,7 @@ async def _guild_bank(ctx: GameContext, player, state: dict, info: dict) -> None
             await ctx.send('Lurch hands it to you.')
 
         else:
-            await ctx.send('R)eview, P)ay, T)ake, or Q to leave.')
+            await ctx.send('[R]eview, [P]ay, [T]ake, or Q to leave.')
 
 
 # ---------------------------------------------------------------------------

--- a/server/items.py
+++ b/server/items.py
@@ -306,7 +306,9 @@ async def ready_weapon(ctx, player, weapons_data: list['Weapon']) -> Optional['W
     await list_weapons(ctx, carried)
 
     while True:
-        raw = await ctx.prompt(f"Ready which weapon number? (or {ctx.player.client_settings.return_key} to cancel) ")
+        raw = await ctx.prompt(
+            'Weapon #',
+            preamble_lines=[f"Ready which weapon number? (or {ctx.player.client_settings.return_key} to cancel)"])
         if not raw or raw.strip() == "":
             return None
 

--- a/server/logon_events/birthday.py
+++ b/server/logon_events/birthday.py
@@ -226,7 +226,9 @@ async def _fist_birthday_party(ctx, player, hn: str, dl: str) -> list[str]:
 
     from bar.vinny import _NPC
 
-    raw = await ctx.prompt(f"{_NPC} eyes you. 'Wanna have a party, {hn}?' (Y/N)")
+    raw = await ctx.prompt(
+        'Y/N',
+        preamble_lines=[f"{_NPC} eyes you. 'Wanna have a party, {hn}?' (Y/N)"])
     if not raw or raw.strip().upper() != 'Y':
         return []
 

--- a/server/monster_editor.py
+++ b/server/monster_editor.py
@@ -428,7 +428,7 @@ async def search_by_flag(ctx, monsters: list[dict]):
                 await ctx.send(f'\nMonsters with [{lbl}]:')
                 for m in results:
                     await ctx.send(f"  #{m['number']:>3} {m['name']}")
-                await ctx.prompt('Press Enter to continue')
+                await ctx.prompt(f'Press {ctx.player.return_key} to continue')
 
             return _show
 
@@ -446,13 +446,13 @@ async def show_special_weapons(ctx, monsters: list[dict], weapons: dict[int, str
     results = [(m, m['special_weapon']) for m in monsters if m.get('special_weapon')]
     if not results:
         await ctx.send('No monsters currently require a special weapon.')
-        await ctx.prompt('Press Enter to continue')
+        await ctx.prompt(f'Press {ctx.player.return_key} to continue')
         return
     await header(ctx, f'Special weapons ({len(results)} monsters)')
     for m, wid in results:
         wname = weapons.get(wid, f'#{wid} (unknown)')
         await ctx.send(f"  #{m['number']:>3}  {m['name']:<25}  requires: {wname}")
-    await ctx.prompt('Press Enter to continue')
+    await ctx.prompt(f'Press {ctx.player.return_key} to continue')
 
 
 async def search_by_attribute(ctx, monsters: list[dict], weapons: dict[int, str]):
@@ -504,7 +504,7 @@ async def search_by_attribute(ctx, monsters: list[dict], weapons: dict[int, str]
                         wpn_str = (f'  [{weapons.get(wpn_id, f"#{wpn_id}")}]'
                                    if wpn_id and weapons else '')
                         await ctx.send(f"  #{m['number']:>3} {m['name']}{wpn_str}")
-                await ctx.prompt('Press Enter to continue')
+                await ctx.prompt(f'Press {ctx.player.return_key} to continue')
 
             return _search
 

--- a/server/ship/ammo_locker.py
+++ b/server/ship/ammo_locker.py
@@ -99,7 +99,9 @@ async def main(ctx: GameContext) -> None:
         lines.append('')
         await ctx.send(lines)
 
-        raw = await ctx.prompt('Your Choice (?=List, Q to leave)')
+        raw = await ctx.prompt(
+            'Your Choice',
+            preamble_lines=['Your Choice (?=List, Q to leave)'])
         if raw is None:
             return
         choice = raw.strip().upper()

--- a/server/ship/ammo_locker.py
+++ b/server/ship/ammo_locker.py
@@ -101,7 +101,7 @@ async def main(ctx: GameContext) -> None:
 
         raw = await ctx.prompt(
             'Your Choice',
-            preamble_lines=['Your Choice (?=List, Q to leave)'])
+            preamble_lines=['Your Choice (?=List, [Q] Leave)'])
         if raw is None:
             return
         choice = raw.strip().upper()

--- a/server/ship/main.py
+++ b/server/ship/main.py
@@ -184,4 +184,4 @@ async def _ship_session(ctx: GameContext, player) -> None:
             await matched(ctx)
         else:
             keys = '/'.join(k for k, _, _ in _MENU)
-            await ctx.send(f'"{raw.strip()}"? ({keys}/SALVAGE/TR/X to choose)')
+            await ctx.send(f'"{raw.strip()}"? ({keys}/SALVAGE/TR/[X] Leave)')

--- a/server/ship/salvage_bay.py
+++ b/server/ship/salvage_bay.py
@@ -70,7 +70,9 @@ async def main(ctx: GameContext) -> None:
         lines.append('')
         await ctx.send(lines)
 
-        raw = await ctx.prompt('Sell which item number? (Q to cancel)')
+        raw = await ctx.prompt(
+            'Item #',
+            preamble_lines=['Sell which item number? (Q to cancel)'])
         if raw is None:
             return
         choice = raw.strip().upper()

--- a/server/ship/salvage_bay.py
+++ b/server/ship/salvage_bay.py
@@ -72,7 +72,7 @@ async def main(ctx: GameContext) -> None:
 
         raw = await ctx.prompt(
             'Item #',
-            preamble_lines=['Sell which item number? (Q to cancel)'])
+            preamble_lines=['Sell which item number? ([Q] Cancel)'])
         if raw is None:
             return
         choice = raw.strip().upper()

--- a/server/ship/transporter.py
+++ b/server/ship/transporter.py
@@ -55,7 +55,7 @@ async def main(ctx: GameContext) -> bool:
             break
         await ctx.send('Wrong!')
 
-    raw = await ctx.prompt('LEVEL: [1] [2] [3] [4] [5]->')
+    raw = await ctx.prompt('LEVEL ->', preamble_lines=['LEVEL: [1] [2] [3] [4] [5]->'])
     if raw is None:
         return False
     try:

--- a/server/shoppe/armory.py
+++ b/server/shoppe/armory.py
@@ -65,14 +65,18 @@ async def _buy(ctx: GameContext, player, inv, all_weapons) -> None:
     while True:
         if _owned_count() >= _WEAPON_MAX:
             raw = await ctx.prompt(
-                'I am sorry, but you have no room for more weapons.  '
-                'Do you wish to sell a weapon?'
-            )
+                'Sell one?',
+                preamble_lines=[
+                    'I am sorry, but you have no room for more weapons.  '
+                    'Do you wish to sell a weapon?'
+                ])
             if raw and raw.strip().upper() == 'Y':
                 await _sell(ctx, player, inv, all_weapons)
             return
 
-        raw = await ctx.prompt(f'Your Choice (?=List, Q to leave{shop_menu_hint(player)})')
+        raw = await ctx.prompt(
+            'Your Choice',
+            preamble_lines=[f'(?=List, Q to leave{shop_menu_hint(player)})'])
         if raw is None:
             return
         choice = raw.strip().upper()
@@ -108,7 +112,7 @@ async def _buy(ctx: GameContext, player, inv, all_weapons) -> None:
         price  = matched['price']
         await ctx.send(f"You choose the {matched['name']} for {price} silver,")
 
-        raw = await ctx.prompt('Do you wish to try it out first?')
+        raw = await ctx.prompt('Try it?', preamble_lines=['Do you wish to try it out first?'])
         if raw and raw.strip().upper() == 'Y':
             wc = matched.get('weapon_class', '')
             await ctx.send([
@@ -187,7 +191,9 @@ async def _sell(ctx: GameContext, player, inv, all_weapons) -> None:
             lines.append(f"  {i}. {entry.item.name}")
         await ctx.send(lines)
 
-        raw = await ctx.prompt(f'Which (Q to leave{shop_menu_hint(player)})')
+        raw = await ctx.prompt(
+            'Which',
+            preamble_lines=[f'Which (Q to leave{shop_menu_hint(player)})'])
         if raw is None or raw.strip().upper() == 'Q':
             return
         choice = raw.strip().upper()
@@ -231,7 +237,7 @@ async def _sell(ctx: GameContext, player, inv, all_weapons) -> None:
                 offer = a * 14
 
         await ctx.send(f"I will give you {offer} silver for the {entry.item.name}.")
-        raw = await ctx.prompt("Doest thou accept MY offer?")
+        raw = await ctx.prompt('Accept?', preamble_lines=["Doest thou accept MY offer?"])
         if raw is None or raw.strip().upper() != 'Y':
             continue
 
@@ -316,7 +322,9 @@ async def _repair(ctx: GameContext, player, inv) -> None:
         lines += ['', 'Q to leave', '']
         await ctx.send(lines)
 
-        raw = await ctx.prompt('Repair which (?=List, Q to leave)')
+        raw = await ctx.prompt(
+            'Item #',
+            preamble_lines=['Repair which (?=List, Q to leave)'])
         if raw is None:
             return
         choice = raw.strip().upper()
@@ -413,7 +421,9 @@ async def protection(ctx: GameContext, *, item_ids: set[int] | None = None) -> N
         lines += ['', 'R to repair', 'Q to leave', '']
         await ctx.send(lines)
 
-        raw = await ctx.prompt(f'Your Choice (?=List{shop_menu_hint(player)})')
+        raw = await ctx.prompt(
+            'Your Choice',
+            preamble_lines=[f'Your Choice (?=List{shop_menu_hint(player)})'])
         if raw is None:
             return
         choice = raw.strip().upper()
@@ -504,7 +514,9 @@ async def main(ctx: GameContext, *, item_ids: set[int] | None = None) -> None:
     await ctx.send('The weapons master eyes you, grinning with a mouthful of yellowed teeth.')
 
     while True:
-        raw = await ctx.prompt('Wouldst thou be interested in [P]rotection or [W]eaponry?')
+        raw = await ctx.prompt(
+            'Choice',
+            preamble_lines=['Wouldst thou be interested in [P]rotection or [W]eaponry?'])
         if raw is None:
             return
         cmd = raw.strip().upper()[:1]
@@ -523,7 +535,7 @@ async def main(ctx: GameContext, *, item_ids: set[int] | None = None) -> None:
         all_weapons = [w for w in all_weapons if w.get('number') in item_ids]
 
     while True:
-        raw = await ctx.prompt('Wouldst thou [B]uy or [S]ell?')
+        raw = await ctx.prompt('Choice', preamble_lines=['Wouldst thou [B]uy or [S]ell?'])
         if raw is None or raw.strip().upper()[:1] in ('', 'Q'):
             return
         cmd = raw.strip().upper()[:1]

--- a/server/shoppe/armory.py
+++ b/server/shoppe/armory.py
@@ -76,7 +76,7 @@ async def _buy(ctx: GameContext, player, inv, all_weapons) -> None:
 
         raw = await ctx.prompt(
             'Your Choice',
-            preamble_lines=[f'(?=List, Q to leave{shop_menu_hint(player)})'])
+            preamble_lines=[f'(?=List, [Q] Leave{shop_menu_hint(player)})'])
         if raw is None:
             return
         choice = raw.strip().upper()
@@ -96,7 +96,7 @@ async def _buy(ctx: GameContext, player, inv, all_weapons) -> None:
         except ValueError:
             if await try_global_command(ctx, raw):
                 continue
-            await ctx.send('Enter a weapon number, ? to list, or Q to leave.')
+            await ctx.send('Enter a weapon number, ? to list, or [Q] Leave.')
             continue
 
         matched = next((w for w in all_weapons if w['number'] == wnum), None)
@@ -193,7 +193,7 @@ async def _sell(ctx: GameContext, player, inv, all_weapons) -> None:
 
         raw = await ctx.prompt(
             'Which',
-            preamble_lines=[f'Which (Q to leave{shop_menu_hint(player)})'])
+            preamble_lines=[f'Which ([Q] Leave{shop_menu_hint(player)})'])
         if raw is None or raw.strip().upper() == 'Q':
             return
         choice = raw.strip().upper()
@@ -319,12 +319,12 @@ async def _repair(ctx: GameContext, player, inv) -> None:
             label     = _condition_label(condition)
             lines.append(f'  {i:>3}. {e.item.name:<22} {condition:>3}%  '
                          f'IN {label} CONDITION{_worn_tag(e.item)}')
-        lines += ['', 'Q to leave', '']
+        lines += ['', '[Q] Leave', '']
         await ctx.send(lines)
 
         raw = await ctx.prompt(
             'Item #',
-            preamble_lines=['Repair which (?=List, Q to leave)'])
+            preamble_lines=['Repair which (?=List, [Q] Leave)'])
         if raw is None:
             return
         choice = raw.strip().upper()
@@ -418,7 +418,7 @@ async def protection(ctx: GameContext, *, item_ids: set[int] | None = None) -> N
             kind  = it['type'].capitalize()
             price = it['price'] * 100  # SPUR: it=it*100
             lines.append(f"  {i:>3}. {it['name']:<22} ({kind})  {price:>6}s")
-        lines += ['', '[R]epair', 'Q to leave', '']
+        lines += ['', '[R]epair', '[Q] Leave', '']
         await ctx.send(lines)
 
         raw = await ctx.prompt(

--- a/server/shoppe/armory.py
+++ b/server/shoppe/armory.py
@@ -418,7 +418,7 @@ async def protection(ctx: GameContext, *, item_ids: set[int] | None = None) -> N
             kind  = it['type'].capitalize()
             price = it['price'] * 100  # SPUR: it=it*100
             lines.append(f"  {i:>3}. {it['name']:<22} ({kind})  {price:>6}s")
-        lines += ['', 'R to repair', 'Q to leave', '']
+        lines += ['', '[R]epair', 'Q to leave', '']
         await ctx.send(lines)
 
         raw = await ctx.prompt(

--- a/server/shoppe/bank.py
+++ b/server/shoppe/bank.py
@@ -79,7 +79,9 @@ async def main(ctx: GameContext) -> None:
             '',
         ])
 
-        raw = await ctx.prompt('[D]eposit, [W]ithdraw, [T]ransfer, or Q to leave')
+        raw = await ctx.prompt(
+            'Choice',
+            preamble_lines=['[D]eposit, [W]ithdraw, [T]ransfer, or Q to leave'])
         if raw is None:
             return
         cmd = raw.strip().upper()[:1]

--- a/server/shoppe/bank.py
+++ b/server/shoppe/bank.py
@@ -161,4 +161,4 @@ async def main(ctx: GameContext) -> None:
                 await ctx.send(f'Transfer failed — could not find account for {target_name}.')
 
         else:
-            await ctx.send('D)eposit, W)ithdraw, T)ransfer, or Q to leave.')
+            await ctx.send('[D]eposit, [W]ithdraw, [T]ransfer, or Q to leave.')

--- a/server/shoppe/bank.py
+++ b/server/shoppe/bank.py
@@ -81,7 +81,7 @@ async def main(ctx: GameContext) -> None:
 
         raw = await ctx.prompt(
             'Choice',
-            preamble_lines=['[D]eposit, [W]ithdraw, [T]ransfer, or Q to leave'])
+            preamble_lines=['[D]eposit, [W]ithdraw, [T]ransfer, or [Q] Leave'])
         if raw is None:
             return
         cmd = raw.strip().upper()[:1]
@@ -161,4 +161,4 @@ async def main(ctx: GameContext) -> None:
                 await ctx.send(f'Transfer failed — could not find account for {target_name}.')
 
         else:
-            await ctx.send('[D]eposit, [W]ithdraw, [T]ransfer, or Q to leave.')
+            await ctx.send('[D]eposit, [W]ithdraw, [T]ransfer, or [Q] Leave.')

--- a/server/shoppe/clan.py
+++ b/server/shoppe/clan.py
@@ -109,7 +109,9 @@ async def main(ctx: GameContext) -> None:
         if is_guild:
             await ctx.send(f'(Plus {_DESERT_HONOR_PENALTY} honor penalty for deserting your Guild!)')
 
-        raw = await ctx.prompt('Which? (1-5, Q to leave, ? to re-list)')
+        raw = await ctx.prompt(
+            'Which',
+            preamble_lines=['Which? (1-5, Q to leave, ? to re-list)'])
         if raw is None:
             return
         choice = raw.strip().upper()
@@ -146,7 +148,9 @@ async def main(ctx: GameContext) -> None:
 
         # Confirm
         sigil_str = f' {sigil}' if sigil else ''
-        raw = await ctx.prompt(f"Join {label}{sigil_str}? (Y/N)")
+        raw = await ctx.prompt(
+            'Confirm (Y/N)',
+            preamble_lines=[f"Join {label}{sigil_str}? (Y/N)"])
         if raw is None or raw.strip().upper() != 'Y':
             continue
 

--- a/server/shoppe/clan.py
+++ b/server/shoppe/clan.py
@@ -111,7 +111,7 @@ async def main(ctx: GameContext) -> None:
 
         raw = await ctx.prompt(
             'Which',
-            preamble_lines=['Which? (1-5, Q to leave, ? to re-list)'])
+            preamble_lines=['Which? (1-5, [Q] Leave, ? to re-list)'])
         if raw is None:
             return
         choice = raw.strip().upper()
@@ -125,7 +125,7 @@ async def main(ctx: GameContext) -> None:
         try:
             n = int(choice)
         except ValueError:
-            await ctx.send('Enter 1 through 5, Q to leave.')
+            await ctx.send('Enter 1 through 5, [Q] Leave.')
             continue
 
         opt = next((o for o in _OPTIONS if o[0] == n), None)

--- a/server/shoppe/elevator.py
+++ b/server/shoppe/elevator.py
@@ -205,7 +205,7 @@ async def _elevator_session(ctx: GameContext, player) -> None:
         lines += ['', '  [L]eave elevator', '']
         await ctx.send(lines)
 
-        raw = await ctx.prompt('Level (or L to leave)')
+        raw = await ctx.prompt('Level (or [L] Leave)')
         if raw is None:
             break
         cmd = raw.strip().lower()
@@ -248,7 +248,7 @@ async def _elevator_session(ctx: GameContext, player) -> None:
             if processor:
                 await processor.process_input(raw.strip(), ctx=ctx)
             else:
-                await ctx.send(f'Please enter a level number (1–{len(available)}) or L to leave.')
+                await ctx.send(f'Please enter a level number (1–{len(available)}) or [L] Leave.')
 
 
 # ---------------------------------------------------------------------------

--- a/server/shoppe/inventory_tools.py
+++ b/server/shoppe/inventory_tools.py
@@ -105,7 +105,9 @@ async def _drop_item(ctx: GameContext, player, inv) -> None:
         return
 
     entries = list(inv)
-    raw = await ctx.prompt(f'Drop which item (1-{len(entries)}, Enter to cancel)')
+    raw = await ctx.prompt(
+        'Item #',
+        preamble_lines=[f'Drop which item (1-{len(entries)}, Enter to cancel)'])
     if raw is None or not raw.strip():
         return
     try:
@@ -118,7 +120,9 @@ async def _drop_item(ctx: GameContext, player, inv) -> None:
 
     entry = entries[choice]
     name = getattr(entry.item, 'name', 'item')
-    confirm = await ctx.prompt(f'Discard the {name} for good? This cannot be undone (y/N)')
+    confirm = await ctx.prompt(
+        'Confirm',
+        preamble_lines=[f'Discard the {name} for good? This cannot be undone (y/N)'])
     if not confirm or confirm.strip().lower() not in ('y', 'yes'):
         await ctx.send('Never mind.')
         return
@@ -152,7 +156,9 @@ async def transfer_main(ctx: GameContext) -> None:
     lines += ['', '[Enter] to cancel']
     await ctx.send(lines)
 
-    raw = await ctx.prompt(f'Transfer which item (1-{len(entries)}, Enter to cancel)')
+    raw = await ctx.prompt(
+        'Item #',
+        preamble_lines=[f'Transfer which item (1-{len(entries)}, Enter to cancel)'])
     if raw is None or not raw.strip():
         return
     try:
@@ -172,7 +178,9 @@ async def transfer_main(ctx: GameContext) -> None:
     lines += ['', '[Enter] to cancel']
     await ctx.send(lines)
 
-    raw = await ctx.prompt(f'Recipient (1-{len(allies)}, Enter to cancel)')
+    raw = await ctx.prompt(
+        'Recipient #',
+        preamble_lines=[f'Recipient (1-{len(allies)}, Enter to cancel)'])
     if raw is None or not raw.strip():
         return
     try:

--- a/server/shoppe/inventory_tools.py
+++ b/server/shoppe/inventory_tools.py
@@ -81,7 +81,7 @@ async def inventory_main(ctx: GameContext) -> None:
             for index, entry in enumerate(inv, 1):
                 lines.append(_format_entry(entry, index))
                 lines.extend(_container_lines(entry))
-        lines += ['', '[S]ort by category, [D]rop an item, [Enter] to leave', '']
+        lines += ['', f'[S]ort by category, [D]rop an item, [{player.return_key}] to leave', '']
         await ctx.send(lines)
 
         raw = await ctx.prompt('Pack')
@@ -96,7 +96,7 @@ async def inventory_main(ctx: GameContext) -> None:
         elif cmd == 'd':
             await _drop_item(ctx, player, inv)
         else:
-            await ctx.send('Unrecognized. [S]ort, [D]rop, or Enter to leave.')
+            await ctx.send(f'Unrecognized. [S]ort, [D]rop, or {player.return_key} to leave.')
 
 
 async def _drop_item(ctx: GameContext, player, inv) -> None:
@@ -107,7 +107,7 @@ async def _drop_item(ctx: GameContext, player, inv) -> None:
     entries = list(inv)
     raw = await ctx.prompt(
         'Item #',
-        preamble_lines=[f'Drop which item (1-{len(entries)}, Enter to cancel)'])
+        preamble_lines=[f'Drop which item (1-{len(entries)}, {player.return_key} to cancel)'])
     if raw is None or not raw.strip():
         return
     try:
@@ -153,12 +153,12 @@ async def transfer_main(ctx: GameContext) -> None:
     lines = ['', 'Your pack:', '']
     for index, entry in enumerate(entries, 1):
         lines.append(_format_entry(entry, index))
-    lines += ['', '[Enter] to cancel']
+    lines += ['', f'[{player.return_key}] to cancel']
     await ctx.send(lines)
 
     raw = await ctx.prompt(
         'Item #',
-        preamble_lines=[f'Transfer which item (1-{len(entries)}, Enter to cancel)'])
+        preamble_lines=[f'Transfer which item (1-{len(entries)}, {player.return_key} to cancel)'])
     if raw is None or not raw.strip():
         return
     try:
@@ -175,12 +175,12 @@ async def transfer_main(ctx: GameContext) -> None:
     lines = ['', 'Send to:', '']
     for i, ally in enumerate(allies, 1):
         lines.append(f'  {i}. {ally.name}')
-    lines += ['', '[Enter] to cancel']
+    lines += ['', f'[{player.return_key}] to cancel']
     await ctx.send(lines)
 
     raw = await ctx.prompt(
         'Recipient #',
-        preamble_lines=[f'Recipient (1-{len(allies)}, Enter to cancel)'])
+        preamble_lines=[f'Recipient (1-{len(allies)}, {player.return_key} to cancel)'])
     if raw is None or not raw.strip():
         return
     try:

--- a/server/shoppe/locker.py
+++ b/server/shoppe/locker.py
@@ -191,7 +191,7 @@ async def _look(ctx: GameContext, player) -> None:
 async def _locker_session(ctx: GameContext, player) -> None:
     await ctx.send(['', 'PRIVATE LOCKER', ''])
     while True:
-        raw = await ctx.prompt('Choice', preamble_lines=['P)ut, T)ake, L)ook, Q)uit'])
+        raw = await ctx.prompt('Choice', preamble_lines=['[P]ut, [T]ake, [L]ook, [Q]uit'])
         if raw is None:
             return
         cmd = raw.strip().upper()[:1]
@@ -205,7 +205,7 @@ async def _locker_session(ctx: GameContext, player) -> None:
         elif cmd == 'L':
             await _look(ctx, player)
         else:
-            await ctx.send('P)ut, T)ake, L)ook, Q)uit')
+            await ctx.send('[P]ut, [T]ake, [L]ook, [Q]uit')
 
 
 # ---------------------------------------------------------------------------

--- a/server/shoppe/locker.py
+++ b/server/shoppe/locker.py
@@ -121,7 +121,9 @@ async def _put(ctx: GameContext, player) -> None:
         return
 
     await ctx.send([''] + _list_lines('You are carrying', entries) + [''])
-    raw = await ctx.prompt('Put which item? (Enter to cancel)')
+    raw = await ctx.prompt(
+        'Item #',
+        preamble_lines=['Put which item? (Enter to cancel)'])
     if not raw or not raw.strip():
         return
     try:
@@ -152,7 +154,9 @@ async def _take(ctx: GameContext, player) -> None:
         return
 
     await ctx.send([''] + _list_lines('The locker contains', entries) + [''])
-    raw = await ctx.prompt('Take which item? (Enter to cancel)')
+    raw = await ctx.prompt(
+        'Item #',
+        preamble_lines=['Take which item? (Enter to cancel)'])
     if not raw or not raw.strip():
         return
     try:
@@ -187,7 +191,7 @@ async def _look(ctx: GameContext, player) -> None:
 async def _locker_session(ctx: GameContext, player) -> None:
     await ctx.send(['', 'PRIVATE LOCKER', ''])
     while True:
-        raw = await ctx.prompt('P)ut, T)ake, L)ook, Q)uit')
+        raw = await ctx.prompt('Choice', preamble_lines=['P)ut, T)ake, L)ook, Q)uit'])
         if raw is None:
             return
         cmd = raw.strip().upper()[:1]

--- a/server/shoppe/locker.py
+++ b/server/shoppe/locker.py
@@ -123,7 +123,7 @@ async def _put(ctx: GameContext, player) -> None:
     await ctx.send([''] + _list_lines('You are carrying', entries) + [''])
     raw = await ctx.prompt(
         'Item #',
-        preamble_lines=['Put which item? (Enter to cancel)'])
+        preamble_lines=[f'Put which item? ({player.return_key} to cancel)'])
     if not raw or not raw.strip():
         return
     try:
@@ -156,7 +156,7 @@ async def _take(ctx: GameContext, player) -> None:
     await ctx.send([''] + _list_lines('The locker contains', entries) + [''])
     raw = await ctx.prompt(
         'Item #',
-        preamble_lines=['Take which item? (Enter to cancel)'])
+        preamble_lines=[f'Take which item? ({player.return_key} to cancel)'])
     if not raw or not raw.strip():
         return
     try:

--- a/server/shoppe/main.py
+++ b/server/shoppe/main.py
@@ -340,7 +340,7 @@ async def _shoppe_session(ctx: GameContext, player) -> None:
             pass
         else:
             keys = '/'.join(k for k, _, _ in menu)
-            await ctx.send(f'"{raw.strip()}"? ({keys}/X to choose)')
+            await ctx.send(f'"{raw.strip()}"? ({keys}/[X] Leave)')
 
 
 # ---------------------------------------------------------------------------

--- a/server/shoppe/main.py
+++ b/server/shoppe/main.py
@@ -82,12 +82,12 @@ async def _general_store(ctx: GameContext, *, numbers: object = None) -> None:
             have = carried_qty.get(num, 0)
             suffix = f'  (have {have})' if have else ''
             lines.append(f'  {len(available):>2}. {name:<20} {kind:<6}  {price:>4}s{suffix}')
-        lines += ['', '[Enter] to leave', '']
+        lines += ['', f'[{player.return_key}] to leave', '']
         await ctx.send(lines)
 
         raw = await ctx.prompt(
             'Item #',
-            preamble_lines=[f'Buy which item (1-{len(available)}, Enter to leave{shop_menu_hint(player)})'])
+            preamble_lines=[f'Buy which item (1-{len(available)}, {player.return_key} to leave{shop_menu_hint(player)})'])
         if not raw or not raw.strip():
             return
 

--- a/server/shoppe/main.py
+++ b/server/shoppe/main.py
@@ -85,7 +85,9 @@ async def _general_store(ctx: GameContext, *, numbers: object = None) -> None:
         lines += ['', '[Enter] to leave', '']
         await ctx.send(lines)
 
-        raw = await ctx.prompt(f'Buy which item (1-{len(available)}, Enter to leave{shop_menu_hint(player)})')
+        raw = await ctx.prompt(
+            'Item #',
+            preamble_lines=[f'Buy which item (1-{len(available)}, Enter to leave{shop_menu_hint(player)})'])
         if not raw or not raw.strip():
             return
 
@@ -179,7 +181,9 @@ async def _player_list(ctx: GameContext) -> None:
         'Examples:  *  (everyone),  r*  (names starting with R).',
         '',
     ])
-    raw = await ctx.prompt('Search pattern (or * for all)')
+    raw = await ctx.prompt(
+        'Pattern',
+        preamble_lines=['Search pattern (or * for all)'])
     if raw is None:
         return
     pattern = raw.strip() or '*'

--- a/server/shoppe/ollys.py
+++ b/server/shoppe/ollys.py
@@ -283,7 +283,9 @@ async def _booby_section(ctx: GameContext, player, inv, objects_by_num: dict) ->
 
     while True:
         await ctx.send(f'Cost=1000.  Purchase Booby Trap.')
-        raw = await ctx.prompt(f'Disarm code [{_BOOBY_CODES}] or Q to leave{shop_menu_hint(player)}')
+        raw = await ctx.prompt(
+            'Code',
+            preamble_lines=[f'Disarm code [{_BOOBY_CODES}] or Q to leave{shop_menu_hint(player)}'])
         if raw is None:
             return
         stripped = raw.strip()
@@ -481,7 +483,9 @@ async def main(ctx: GameContext) -> None:
     from shoppe.inventory_tools import handle_shop_key, shop_menu_hint
 
     while True:
-        raw = await ctx.prompt(f'[A]mmo, [B]ooby traps, [H]elp, or Q to leave{shop_menu_hint(player)}')
+        raw = await ctx.prompt(
+            'Choice',
+            preamble_lines=[f'[A]mmo, [B]ooby traps, [H]elp, or Q to leave{shop_menu_hint(player)}'])
         if raw is None:
             return
         cmd = raw.strip().upper()[:1]

--- a/server/shoppe/ollys.py
+++ b/server/shoppe/ollys.py
@@ -135,7 +135,7 @@ async def _ammo_section(ctx: GameContext, player, inv, objects_by_num: dict) -> 
         lines += _ammo_table().render(width=width)
         lines += ['', '  [[ Ammo Carriers ]]', '']
         lines += _carrier_table().render(width=width)
-        lines += ['', f'Enter item number, ? to re-list{shop_menu_hint(player)}, or Q to leave.', '']
+        lines += ['', f'Enter item number, ? to re-list{shop_menu_hint(player)}, or [Q] Leave.', '']
         await ctx.send(lines)
 
         raw = await ctx.prompt('Your Choice')
@@ -160,7 +160,7 @@ async def _ammo_section(ctx: GameContext, player, inv, objects_by_num: dict) -> 
         except ValueError:
             if await try_global_command(ctx, raw):
                 continue
-            await ctx.send('Enter a number, ? to list, [I]nventory, or Q to leave.')
+            await ctx.send('Enter a number, ? to list, [I]nventory, or [Q] Leave.')
             continue
 
         it = index_to_item.get(num)
@@ -285,7 +285,7 @@ async def _booby_section(ctx: GameContext, player, inv, objects_by_num: dict) ->
         await ctx.send(f'Cost=1000.  Purchase Booby Trap.')
         raw = await ctx.prompt(
             'Code',
-            preamble_lines=[f'Disarm code [{_BOOBY_CODES}] or Q to leave{shop_menu_hint(player)}'])
+            preamble_lines=[f'Disarm code [{_BOOBY_CODES}] or [Q] Leave{shop_menu_hint(player)}'])
         if raw is None:
             return
         stripped = raw.strip()
@@ -485,7 +485,7 @@ async def main(ctx: GameContext) -> None:
     while True:
         raw = await ctx.prompt(
             'Choice',
-            preamble_lines=[f'[A]mmo, [B]ooby traps, [H]elp, or Q to leave{shop_menu_hint(player)}'])
+            preamble_lines=[f'[A]mmo, [B]ooby traps, [H]elp, or [Q] Leave{shop_menu_hint(player)}'])
         if raw is None:
             return
         cmd = raw.strip().upper()[:1]
@@ -502,4 +502,4 @@ async def main(ctx: GameContext) -> None:
         elif await try_global_command(ctx, raw):
             pass
         else:
-            await ctx.send('[A]mmo, [B]ooby traps, [H]elp, or Q to leave.')
+            await ctx.send('[A]mmo, [B]ooby traps, [H]elp, or [Q] Leave.')

--- a/server/shoppe/ollys.py
+++ b/server/shoppe/ollys.py
@@ -160,7 +160,7 @@ async def _ammo_section(ctx: GameContext, player, inv, objects_by_num: dict) -> 
         except ValueError:
             if await try_global_command(ctx, raw):
                 continue
-            await ctx.send('Enter a number, ? to list, I)nventory, or Q to leave.')
+            await ctx.send('Enter a number, ? to list, [I]nventory, or Q to leave.')
             continue
 
         it = index_to_item.get(num)
@@ -502,4 +502,4 @@ async def main(ctx: GameContext) -> None:
         elif await try_global_command(ctx, raw):
             pass
         else:
-            await ctx.send('A)mmo, B)ooby traps, H)elp, or Q to leave.')
+            await ctx.send('[A]mmo, [B]ooby traps, [H]elp, or Q to leave.')

--- a/server/shoppe/pawn.py
+++ b/server/shoppe/pawn.py
@@ -113,7 +113,7 @@ async def main(ctx: GameContext) -> None:
 
             raw = await ctx.prompt(
                 'Item #',
-                preamble_lines=['Buy which item number? (Q to cancel)'])
+                preamble_lines=['Buy which item number? ([Q] Cancel)'])
             if raw is None:
                 return
             choice = raw.strip().upper()
@@ -170,7 +170,7 @@ async def main(ctx: GameContext) -> None:
 
         raw = await ctx.prompt(
             'Item #',
-            preamble_lines=['Sell which item number? (Q to cancel)'])
+            preamble_lines=['Sell which item number? ([Q] Cancel)'])
         if raw is None:
             return
         choice = raw.strip().upper()

--- a/server/shoppe/pawn.py
+++ b/server/shoppe/pawn.py
@@ -87,7 +87,9 @@ async def main(ctx: GameContext) -> None:
         ]
         stock = ctx.server.pawn_stock
 
-        raw = await ctx.prompt(f'[S]ell, [B]uy, [Q]uit{shop_menu_hint(player)}')
+        raw = await ctx.prompt(
+            'Choice',
+            preamble_lines=[f'[S]ell, [B]uy, [Q]uit{shop_menu_hint(player)}'])
         if raw is None:
             return
         cmd = raw.strip().upper()[:1]
@@ -109,7 +111,9 @@ async def main(ctx: GameContext) -> None:
             lines.append('')
             await ctx.send(lines)
 
-            raw = await ctx.prompt('Buy which item number? (Q to cancel)')
+            raw = await ctx.prompt(
+                'Item #',
+                preamble_lines=['Buy which item number? (Q to cancel)'])
             if raw is None:
                 return
             choice = raw.strip().upper()
@@ -164,7 +168,9 @@ async def main(ctx: GameContext) -> None:
         lines.append('')
         await ctx.send(lines)
 
-        raw = await ctx.prompt('Sell which item number? (Q to cancel)')
+        raw = await ctx.prompt(
+            'Item #',
+            preamble_lines=['Sell which item number? (Q to cancel)'])
         if raw is None:
             return
         choice = raw.strip().upper()

--- a/server/shoppe/school.py
+++ b/server/shoppe/school.py
@@ -79,7 +79,9 @@ async def main(ctx: GameContext) -> None:
         await ctx.send('Ye do not have enough gold.')
         return
 
-    raw = await ctx.prompt('Do ye wish shield training? Y/N')
+    raw = await ctx.prompt(
+        'Y/N',
+        preamble_lines=['Do ye wish shield training? Y/N'])
     if raw is None or raw.strip().upper() != 'Y':
         return
 

--- a/server/shoppe/wizard.py
+++ b/server/shoppe/wizard.py
@@ -284,7 +284,7 @@ async def main(ctx: GameContext) -> None:
 
         raw = await ctx.prompt(
             'Learn which spell?',
-            preamble_lines=[f'(?=List, i#=Info, BOOK=Buy Spell Book, Q to leave{shop_menu_hint(player)})'])
+            preamble_lines=[f'(?=List, i#=Info, BOOK=Buy Spell Book, [Q] Leave{shop_menu_hint(player)})'])
         if raw is None:
             return
         choice = raw.strip()
@@ -322,7 +322,7 @@ async def main(ctx: GameContext) -> None:
         except ValueError:
             if await try_global_command(ctx, raw):
                 continue
-            await ctx.send('Enter a spell number, ? to list, i# for info, or Q to leave.')
+            await ctx.send('Enter a spell number, ? to list, i# for info, or [Q] Leave.')
             continue
 
         sp = next((s for s in SPELLS if s['number'] == num), None)

--- a/server/spells/charm.py
+++ b/server/spells/charm.py
@@ -213,7 +213,9 @@ async def try_charm_join_offer(ctx: 'GameContext', *, level: int, room_no: int) 
         player.pending_charm = None
         return
 
-    raw = await ctx.prompt(f'{mdisp} wants to join you! OK? (Y/N)')
+    raw = await ctx.prompt(
+        'Y/N',
+        preamble_lines=[f'{mdisp} wants to join you! OK? (Y/N)'])
     if not raw or raw.strip().upper() != 'Y':
         if int(getattr(player, 'honor', 0) or 0) > _DECLINE_HONOR_PENALTY:
             player.adjust_honor(-_DECLINE_HONOR_PENALTY)

--- a/server/street/allies_guild.py
+++ b/server/street/allies_guild.py
@@ -47,7 +47,9 @@ _COST_TRACKING   = 750
 async def _confirm_and_charge(ctx: GameContext, ally: Ally, label: str, cost: int) -> bool:
     """Prompt for confirmation, then charge *cost* gold.  Returns True on success."""
     player = ctx.player
-    raw = await ctx.prompt(f'Ye want {ally.name} {label} for {cost} gold? y/N')
+    raw = await ctx.prompt(
+        'Confirm (y/N)',
+        preamble_lines=[f'Ye want {ally.name} {label} for {cost} gold? y/N'])
     if not raw or raw.strip().upper() != 'Y':
         return False
     if not player.subtract_silver(PlayerMoneyTypes.IN_HAND, cost):

--- a/server/street/jakes.py
+++ b/server/street/jakes.py
@@ -137,7 +137,9 @@ async def _buy_ration(ctx: GameContext, ration_num: int) -> None:
         await ctx.send('You do not have enough gold.')
         return
 
-    raw = await ctx.prompt(f"You choose {chosen['name']} for {price} gold? (Y/N)")
+    raw = await ctx.prompt(
+        'Confirm (Y/N)',
+        preamble_lines=[f"You choose {chosen['name']} for {price} gold? (Y/N)"])
     if not raw or raw.strip().upper() != 'Y':
         return
 
@@ -171,7 +173,9 @@ async def _buy_item(ctx: GameContext, item_num: int) -> None:
         await ctx.send('You do not have enough gold.')
         return
 
-    raw = await ctx.prompt(f'You choose {name} for {price} gold? (Y/N)')
+    raw = await ctx.prompt(
+        'Confirm (Y/N)',
+        preamble_lines=[f'You choose {name} for {price} gold? (Y/N)'])
     if not raw or raw.strip().upper() != 'Y':
         return
 
@@ -206,7 +210,9 @@ async def _train_horse(ctx: GameContext) -> None:
         await ctx.send('Thy mount already IS trained!')
         return
 
-    raw = await ctx.prompt(f'Ye want me to train yer horse for {_TRAIN_COST} gold? (Y/N)')
+    raw = await ctx.prompt(
+        'Confirm (Y/N)',
+        preamble_lines=[f'Ye want me to train yer horse for {_TRAIN_COST} gold? (Y/N)'])
     if not raw or raw.strip().upper() != 'Y':
         return
     if not player.subtract_silver(PlayerMoneyTypes.IN_HAND, _TRAIN_COST):

--- a/server/tada_utilities.py
+++ b/server/tada_utilities.py
@@ -162,7 +162,9 @@ async def input_number_range(ctx: 'GameContext',
     oob = out_of_bounds_msg or f'Please enter a number between {min_value} and {max_value}.'
 
     while True:
-        raw = await ctx.prompt(ctx, prompt_text=f'{prompt_msg} [{min_value}-{max_value}]: ')
+        raw = await ctx.prompt(
+            '#',
+            preamble_lines=[f'{prompt_msg} [{min_value}-{max_value}]'])
 
         if raw == '':
             return default

--- a/server/tests/admin/test_editplayer.py
+++ b/server/tests/admin/test_editplayer.py
@@ -84,6 +84,10 @@ class _MockPlayer:
     def query_flag(self, flag) -> bool:
         return flag in self._flags
 
+    @property
+    def return_key(self) -> str:
+        return self.client_settings.return_key
+
     def set_flag(self, flag) -> None:
         self._flags.add(flag)
 

--- a/server/tests/admin/test_list_locations.py
+++ b/server/tests/admin/test_list_locations.py
@@ -303,8 +303,9 @@ class TestTeleportOption(unittest.IsolatedAsyncioTestCase):
                         prompt_answer='')
         ctx.player.return_key = 'Return'
         await cmd.execute(ctx, '#w', '#tel')
-        prompt_text = ctx.prompt.await_args.args[0]
-        self.assertIn('Return', prompt_text)
+        call = ctx.prompt.await_args
+        preamble = call.kwargs.get('preamble_lines') or []
+        self.assertIn('Return', ' '.join(preamble) + call.args[0])
 
     async def test_tel_flag_cancel_on_blank(self):
         cmd = ListLocationsCommand()

--- a/server/tests/horses/test_class_taming.py
+++ b/server/tests/horses/test_class_taming.py
@@ -37,6 +37,7 @@ class _FakePlayer:
         # _FakePlayer for why (Party has no .append(), only add_member()).
         self.party = Party(allies)
         self.unsaved_changes = False
+        self.return_key = 'Enter'
 
 
 class _FakeClient:

--- a/server/tests/movement/test_elevator_session.py
+++ b/server/tests/movement/test_elevator_session.py
@@ -353,7 +353,7 @@ class TestElevatorFallThrough(unittest.IsolatedAsyncioTestCase):
         player = make_player()
         ctx    = make_ctx(player, ['gibberish', 'l'], processor=None)
         await _elevator_session(ctx, player)
-        self.assertIn('L to leave', _sent(ctx))
+        self.assertIn('[L] Leave', _sent(ctx))
 
     @_PATCH_COMBO
     @_PATCH_ULINE

--- a/server/tests/new-player/test_new_player_prompts.py
+++ b/server/tests/new-player/test_new_player_prompts.py
@@ -34,11 +34,12 @@ from tada_utilities import input_yes_no
 
 
 class _FakePlayer:
-    is_expert = False
-    gender    = 'male'
-    age       = None
-    birthday  = None
-    name      = None
+    is_expert  = False
+    gender     = 'male'
+    age        = None
+    birthday   = None
+    name       = None
+    return_key = 'Enter'
 
 
 class _FakeCtx:

--- a/server/tests/new-player/test_new_player_quit_resume.py
+++ b/server/tests/new-player/test_new_player_quit_resume.py
@@ -125,7 +125,7 @@ class TestMainFlowAbandonOrResumePrompt(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result.error, 'abandoned')
         text = ctx._flat()
         self.assertIn("Resuming later isn't possible yet", text)
-        self.assertNotIn('(R)esume', text)
+        self.assertNotIn('[R]esume', text)
 
     async def test_quit_after_username_offers_abandon_or_resume_prompt(self):
         from player import Player
@@ -133,8 +133,8 @@ class TestMainFlowAbandonOrResumePrompt(unittest.IsolatedAsyncioTestCase):
         ctx = _Ctx(['Thorgar', '', 'quit'])  # name, username(blank->default), quit at prefs
         result = await main_flow(ctx, player=player)
         self.assertFalse(result.success)
-        self.assertIn('(A)bandon', ctx._flat())
-        self.assertIn('(R)esume later', ctx._flat())
+        self.assertIn('[A]bandon', ctx._flat())
+        self.assertIn('[R]esume later', ctx._flat())
 
     async def test_choosing_abandon_discards_everything(self):
         from player import Player

--- a/server/tests/shoppe/test_ollys.py
+++ b/server/tests/shoppe/test_ollys.py
@@ -227,7 +227,7 @@ class TestAmmoSectionPurchase(unittest.IsolatedAsyncioTestCase):
         player = _funded_player(1000)
         ctx = _FakeCtx(['xyz', 'q'], player)
         await _ammo_section(ctx, player, player.inventory, self.objects_by_num)
-        self.assertIn('Enter a number, ? to list, [I]nventory, or Q to leave.', ctx._flat())
+        self.assertIn('Enter a number, ? to list, [I]nventory, or [Q] Leave.', ctx._flat())
 
     async def test_question_mark_relists(self):
         player = _funded_player(1000)
@@ -341,7 +341,7 @@ class TestOllysMainDispatch(unittest.IsolatedAsyncioTestCase):
         ctx = _FakeCtx(['zzz', 'q'], player)
         with patch('shoppe.ollys.try_global_command', new=AsyncMock(return_value=False)):
             await ollys_main(ctx)
-        self.assertIn('[A]mmo, [B]ooby traps, [H]elp, or Q to leave.', ctx._flat())
+        self.assertIn('[A]mmo, [B]ooby traps, [H]elp, or [Q] Leave.', ctx._flat())
 
 
 if __name__ == '__main__':

--- a/server/tests/shoppe/test_ollys.py
+++ b/server/tests/shoppe/test_ollys.py
@@ -227,7 +227,7 @@ class TestAmmoSectionPurchase(unittest.IsolatedAsyncioTestCase):
         player = _funded_player(1000)
         ctx = _FakeCtx(['xyz', 'q'], player)
         await _ammo_section(ctx, player, player.inventory, self.objects_by_num)
-        self.assertIn('Enter a number, ? to list, I)nventory, or Q to leave.', ctx._flat())
+        self.assertIn('Enter a number, ? to list, [I]nventory, or Q to leave.', ctx._flat())
 
     async def test_question_mark_relists(self):
         player = _funded_player(1000)
@@ -341,7 +341,7 @@ class TestOllysMainDispatch(unittest.IsolatedAsyncioTestCase):
         ctx = _FakeCtx(['zzz', 'q'], player)
         with patch('shoppe.ollys.try_global_command', new=AsyncMock(return_value=False)):
             await ollys_main(ctx)
-        self.assertIn('A)mmo, B)ooby traps, H)elp, or Q to leave.', ctx._flat())
+        self.assertIn('[A]mmo, [B]ooby traps, [H]elp, or Q to leave.', ctx._flat())
 
 
 if __name__ == '__main__':

--- a/server/tests/social/test_board_command.py
+++ b/server/tests/social/test_board_command.py
@@ -278,8 +278,13 @@ class TestPostAndReply(BoardCommandTestCase):
                       'replies': []}])
         ctx = make_ctx(prompts=['n', '', 'my reply text', '.s'])
         run(BoardCommand().execute(ctx, 'reply', '1'))
-        prompt_args = [c.args[0] for c in ctx.prompt.await_args_list]
-        self.assertIn('Enter title of reply, [Enter keeps same]', prompt_args)
+        prompt_texts = [c.args[0] for c in ctx.prompt.await_args_list]
+        prompt_texts += [
+            line
+            for c in ctx.prompt.await_args_list
+            for line in (c.kwargs.get('preamble_lines') or [])
+        ]
+        self.assertIn('Enter title of reply, [Enter keeps same]', prompt_texts)
 
     def test_reply_confirmation_shows_number_and_title_not_thread_id(self):
         self._seed([{'id': 7, 'title': 'A Bulletin About Cheese', 'author': 'bob',

--- a/server/tests/social/test_board_reply.py
+++ b/server/tests/social/test_board_reply.py
@@ -372,8 +372,13 @@ class TestReplyWithQuote(BoardReplyTestCase):
         prompts = ['r', 'all', 'y', 'n', '', 'my reply', '.s', '', '', '']
         ctx = make_ctx(prompts=prompts)
         run(read_thread_interactive(ctx, _thread()))
-        prompt_args = [c.args[0] for c in ctx.prompt.await_args_list]
-        self.assertIn('Enter title of reply, [Enter keeps same]', prompt_args)
+        prompt_texts = [c.args[0] for c in ctx.prompt.await_args_list]
+        prompt_texts += [
+            line
+            for c in ctx.prompt.await_args_list
+            for line in (c.kwargs.get('preamble_lines') or [])
+        ]
+        self.assertIn('Enter title of reply, [Enter keeps same]', prompt_texts)
 
     def test_reply_header_shows_its_own_title_when_read_back(self):
         # read_thread_interactive() snapshots 'messages' once at the top

--- a/server/tools/bot_epic_battle.py
+++ b/server/tools/bot_epic_battle.py
@@ -141,6 +141,7 @@ class Bot:
         self.monster_present = False
         self.monster_dead = False
         self.last_prompt = ''
+        self.last_lines_text = ''
         self.done = False
 
         self.mount_captured = False
@@ -208,7 +209,8 @@ class Bot:
         msg = json.loads(raw.strip())
         _wrap_recv(self.label, msg)
         self.last_prompt = msg.get('prompt', '') or ''
-        self._update_belief(_text_of(msg))
+        self.last_lines_text = _text_of(msg)
+        self._update_belief(self.last_lines_text)
 
         # Auto-decline a shadow-ally recruit offer (encounters/monster.py's
         # try_shadow_ally(), ~50% chance right after ANY kill, PC or bystander,
@@ -235,11 +237,20 @@ class Bot:
         # name is actually given) until its message budget ran out,
         # overwriting last_prompt along the way and losing the prompt
         # entirely -- leaving it permanently unanswered.
+        #
+        # CAST's own long instructional text ("Cast which spell number?
+        # (?=list, Q to leave)") later moved out of prompt_text into
+        # preamble_lines (commands/cast.py, the alpha-tester too-long-
+        # prompt-lines fix) -- so it now arrives in THIS message's lines,
+        # not its prompt field, while prompt_text itself shrank to just
+        # 'Spell #'. Check both fields so this still matches regardless
+        # of which one carries it.
         low_prompt = self.last_prompt.lower()
+        low_lines  = self.last_lines_text.lower()
         if 'name your horse' in low_prompt:
             self.name_warning_seen = True
             self._bump('lasso_outcome_count')
-        if 'cast which spell number' in low_prompt:
+        if 'cast which spell number' in low_prompt or 'cast which spell number' in low_lines:
             self._bump('cast_prompt_count')
 
         return msg
@@ -770,7 +781,8 @@ async def phase_ronney(hero: Bot, anchor: Bot) -> None:
     await bystander_action(hero, 'attack')
     if hero.is_attacker and not hero.monster_dead:
         await say_and_await(hero, 'cast', 'cast_prompt_count')
-        if 'cast which spell number' in hero.last_prompt.lower():
+        if ('cast which spell number' in hero.last_prompt.lower()
+                or 'cast which spell number' in hero.last_lines_text.lower()):
             await bystander_action(hero, '1')   # SLAUGHTER: M-type, 90% cast chance
 
     # LURK -- fire over BATMAN/ARTHUR DENT's shoulders and force RONNEY's

--- a/server/tools/prompt_preamble_demo.py
+++ b/server/tools/prompt_preamble_demo.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""tools/prompt_preamble_demo.py — renders, through the real send()/
+prompt() formatting pipeline, the ctx.prompt() call sites that were
+reworked so long inline option text moves into `preamble_lines` (which
+word-wraps to the player's actual screen width, see tada_utilities.py /
+network_context.py) instead of being baked unwrapped into `prompt_text`
+(sent raw, never wrapped -- the alpha-tester complaint this fixes).
+
+This drives the real production functions (not reimplemented copies) with
+a genuine Player and a fake reader/writer/server standing in for the
+socket, so what's printed is exactly what a client receives on the wire:
+every `ctx.send()` becomes one JSON Message with wrapped `lines`, and
+every `ctx.prompt()` becomes one Message with wrapped `lines` (the
+preamble) followed by a short raw `prompt`.
+
+Each scenario is answered just enough to reach its target prompt and then
+immediately cancel out (Q/Enter/blank), so this only exercises the fixed
+prompt itself, not the rest of each command's flow.
+
+Run from server/:
+    .venv/bin/python3 tools/prompt_preamble_demo.py [columns]
+
+Default column width is 40 (C64 default). Pass e.g. 80 to compare against
+a wider client.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+logging.basicConfig(level=logging.WARNING)
+
+import net_common as nc
+from network_context import GameContext
+from player import Player
+
+
+# ---------------------------------------------------------------------------
+# Fake transport — same pattern as tests/social/test_messaging.py's
+# test_prompt_prepends_and_clears_pending_pages
+# ---------------------------------------------------------------------------
+
+class _FakeWriter:
+    async def drain(self) -> None:
+        pass
+
+    def write(self, data: bytes) -> None:
+        pass
+
+
+class _FakeReader:
+    """Hands back one canned response per readline(), JSON-encoded exactly
+    like a real client reply."""
+
+    def __init__(self, responses: list[str]):
+        self._q = list(responses)
+
+    async def readline(self) -> bytes:
+        text = self._q.pop(0) if self._q else ''
+        return nc.to_jsonb({'text': text}) + b'\n'
+
+
+class _RecordingServer:
+    """Captures every Message that would have gone out over the wire."""
+
+    def __init__(self):
+        self.clients: dict = {}
+        self.sent_messages: list[nc.Message] = []
+
+    async def send_message(self, writer, obj) -> None:
+        self.sent_messages.append(obj)
+
+
+def _make_ctx(columns: int, responses: list[str]) -> tuple[GameContext, _RecordingServer]:
+    from terminal import Translation
+
+    player = Player(name='Rulan')
+    player.client_settings.screen_columns = columns
+    player.client_settings.translation = Translation.ASCII  # plain text for this demo
+
+    from flags import PlayerFlags
+    player.clear_flag(PlayerFlags.HOURGLASS)  # no clock-prefix noise in this demo
+    server = _RecordingServer()
+    ctx = GameContext(
+        player = player,
+        reader = _FakeReader(responses),
+        writer = _FakeWriter(),
+        server = server,
+        client = SimpleNamespace(room=1),
+    )
+    return ctx, server
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+def _render(title: str, source: str, columns: int, server: _RecordingServer) -> None:
+    bar = '+' + '-' * (columns + 2) + '+'
+    print(f'\n=== {title}  ({source}) ===')
+    print(f'[{columns}-column client]')
+    print(bar)
+    for msg in server.sent_messages:
+        for line in msg.lines:
+            print(f'| {line:<{columns}} |')
+        # ctx.send() stamps every message with the ambient status prompt
+        # ('> ') too -- only a genuine ctx.prompt() call (empty lines,
+        # its own prompt text) is what we're here to look at.
+        if msg.prompt and not msg.lines:
+            label = f'>>> {msg.prompt}'
+            print(f'| {label:<{columns}} |')
+    print(bar)
+
+
+# ---------------------------------------------------------------------------
+# Scenarios — one per fixed call site
+# ---------------------------------------------------------------------------
+
+async def demo_ready_weapon(columns: int) -> None:
+    from items import Weapon
+    ctx, server = _make_ctx(columns, [''])  # blank = cancel
+    weapons = [
+        Weapon(id_number=1, name='Rusty Dagger', location=0,
+               stability=80, to_hit=60, price=15),
+        Weapon(id_number=2, name='Broadsword of Whacking', location=0,
+               stability=95, to_hit=75, price=250),
+    ]
+    from items import ready_weapon
+    await ready_weapon(ctx, ctx.player, weapons)
+    _render('READY weapon', 'items.py:ready_weapon()', columns, server)
+
+
+async def demo_armory_buy(columns: int) -> None:
+    from shoppe.armory import _buy
+    ctx, server = _make_ctx(columns, ['Q'])
+    all_weapons = []  # empty catalog is fine -- we only reach the choice prompt
+    await _buy(ctx, ctx.player, ctx.player.inventory, all_weapons)
+    _render('Armory — buy a weapon', 'shoppe/armory.py:_buy()', columns, server)
+
+
+async def demo_guild_food_locker(columns: int) -> None:
+    from guild_hq.main import _food_locker
+    ctx, server = _make_ctx(columns, ['Q'])
+    state = {'food_locker': [], 'log': []}
+    await _food_locker(ctx, ctx.player, state, {})
+    _render('Guild HQ — food locker', 'guild_hq/main.py:_food_locker()', columns, server)
+
+
+async def demo_little_girl(columns: int) -> None:
+    from encounters.little_girl import try_encounter
+    from base_classes import Map, Room
+
+    ctx, server = _make_ctx(columns, ['I'])  # Ignore -- fewest follow-on prompts
+    game_map = Map()
+    rooms = {1: Room(number=1, name='Room One', desc='', exits={}, monster=0, flags=[])}
+    game_map.levels[1] = rooms
+    game_map.rooms = rooms
+    ctx.server.game_map = game_map
+
+    import random
+    orig_uniform, orig_randint = random.uniform, random.randint
+    random.uniform = lambda a, b: 0.0    # force the encounter to trigger
+    random.randint = lambda a, b: 1      # force the "runs away" branch (no further prompts)
+    try:
+        await try_encounter(ctx)
+    finally:
+        random.uniform, random.randint = orig_uniform, orig_randint
+    _render('Little girl encounter', 'encounters/little_girl.py:try_encounter()', columns, server)
+
+
+async def demo_general_store(columns: int) -> None:
+    from shoppe.main import _general_store
+    ctx, server = _make_ctx(columns, [''])  # blank = leave
+    await _general_store(ctx)
+    _render('General Store — buy', 'shoppe/main.py:_general_store()', columns, server)
+
+
+SCENARIOS = [
+    demo_ready_weapon,
+    demo_armory_buy,
+    demo_guild_food_locker,
+    demo_little_girl,
+    demo_general_store,
+]
+
+
+async def main() -> None:
+    columns = int(sys.argv[1]) if len(sys.argv) > 1 else 40
+    for scenario in SCENARIOS:
+        await scenario(columns)
+
+
+if __name__ == '__main__':
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- Long `ctx.prompt()` option/instructional text was baked into `prompt_text`, which is sent raw and never word-wrapped (unlike `preamble_lines`, which wraps to the player's screen width) — causing overflow on narrow (40-column C64) clients. Moved ~104 call sites' option text into `preamble_lines`, keeping `prompt_text` short.
- Replaced hard-coded `"Enter"` / `"blank to cancel"` strings with `{ctx.player.return_key}` so prompts reflect the player's actual negotiated Return-key label instead of assuming Enter.
- Normalized action-key notation (`X)word`, `(X)word`, `'R' for random`, `Q to leave`) to a single `[X]word` / `[X] Word` style so `highlight_brackets()` actually highlights the key — the only format it colorizes.
- Added `tools/prompt_preamble_demo.py`, a harness that drives several fixed call sites through the real `send()`/`prompt()` formatting pipeline and renders the wrapped output at a given column width, for visual verification.
- Fixed a latent bug in `tada_utilities.input_number_range()` (stray `ctx` positional arg colliding with the `prompt_text` keyword) and a `tools/bot_epic_battle.py` wait-condition that stopped matching once its target text moved from `prompt` to `lines`.
- Added a TODO.md entry for a `%k` `substitute_tokens()` token, for static text (e.g. `Help()` descriptions) that can't reach a live `ctx.player`.

## Test plan
- [x] Full suite: `4362 passed, 2 skipped` (2 pre-existing, unrelated failures in `test_get_unconscious.py`/`test_give_take.py`, unchanged from baseline before this branch)
- [x] `tools/prompt_preamble_demo.py` run at both 40 and 80 columns to visually confirm wrapping behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ARfpES74ivVNVmVB29pcV