### PR TITLE
ally_events: rename gold-find event to silver

### DIFF
--- a/server/ally_events/__init__.py
+++ b/server/ally_events/__init__.py
@@ -1,6 +1,6 @@
 """ally_events/__init__.py — Ally-triggered events.
 
-  try_ally_find_gold    — random per-move gold-finding (SPUR MISC6.S al.find)
+  try_ally_find_silver  — random per-move silver-finding (SPUR MISC6.S al.find)
   try_hungry_ally       — intercept player eating/drinking for a hungry ally
                           (SPUR SUB.S hun.slv)
   try_ally_death_save   — ally intercession when a monster blow would kill
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 # once_per_day tag that mirrors SPUR's "*AYF" flag in ys$
-_OPD_ALLY_GOLD = 'AYF'
+_OPD_ALLY_SILVER = 'AYF'
 
 # Approximate probability: SPUR fires the whole event pool ~15% of moves,
 # and ally-gold is 1 of 6 outcomes (~2.5% net).  We use a flat 5% which is
@@ -37,8 +37,8 @@ _OPD_ALLY_GOLD = 'AYF'
 _CHANCE = 0.05
 
 
-async def try_ally_find_gold(ctx: GameContext) -> None:
-    """Maybe have a SERVANT ally find a sack of gold for the player.
+async def try_ally_find_silver(ctx: GameContext) -> None:
+    """Maybe have a SERVANT ally find a sack of silver for the player.
 
     Skips silently if:
       - player has no SERVANT allies
@@ -64,7 +64,7 @@ async def try_ally_find_gold(ctx: GameContext) -> None:
     once = getattr(player, 'once_per_day', None)
     if once is None:
         return
-    if _OPD_ALLY_GOLD in once:
+    if _OPD_ALLY_SILVER in once:
         return
 
     # Guard: must have at least one ally in party (any status)
@@ -81,27 +81,27 @@ async def try_ally_find_gold(ctx: GameContext) -> None:
     ally = allies[0]
     ally_name = ally.name
 
-    # Gold amount: (roll*2)+50 → range 52-250 gp  (SPUR: z=(z*2)+50)
+    # Silver amount: (roll*2)+50 → range 52-250 silver  (SPUR: z=(z*2)+50)
     roll = random.randint(1, 100)
     amount = (roll * 2) + 50
 
-    # Transfer gold
+    # Transfer silver
     try:
         kind    = PlayerMoneyTypes.IN_HAND
         current = player.get_silver(kind)
         player.set_silver_absolute(kind, current + amount)
     except Exception:
-        log.exception('try_ally_find_gold: error crediting %d gp to %s', amount, player.name)
+        log.exception('try_ally_find_silver: error crediting %d silver to %s', amount, player.name)
         return
 
     # Mark fired for today
-    once.append(_OPD_ALLY_GOLD)
+    once.append(_OPD_ALLY_SILVER)
     player.unsaved_changes = True
 
     await ctx.send([
         f"'Look what I found!' shouts {ally_name}",
-        f'{ally_name} hands you a gold sack!',
-        f'({amount} gp)',
+        f'{ally_name} hands you a sack of silver.',
+        f'({amount} silver)',
         f'{ally_name} swaggers proudly.',
     ])
 

--- a/server/ally_events/starvation.py
+++ b/server/ally_events/starvation.py
@@ -6,8 +6,8 @@ Part of the same random-event dispatcher as encounters/little_girl.py,
 encounters/meteor.py, and encounters/djinn_sighting.py -- see
 little_girl.py's docstring for why this rolls its own flat composite
 share instead of a shared dispatcher for now. (The dispatcher's sibling
-sub-event, an ally finding gold / SPUR's `al.find`, already exists as
-ally_events/__init__.py's try_ally_find_gold() -- not duplicated here.
+sub-event, an ally finding silver / SPUR's `al.find`, already exists as
+ally_events/__init__.py's try_ally_find_silver() -- not duplicated here.
 Lives in ally_events/ rather than encounters/ for that reason: it's a
 sibling of that existing ally mechanic, not one of the encounters/
 package's own room/NPC events.)

--- a/server/simple_server.py
+++ b/server/simple_server.py
@@ -1266,8 +1266,8 @@ class Server:
         await self._show_room_then_encounter(ctx, level=level, room_no=int(dest))
         from encounters.desert import try_desert_sweat
         await try_desert_sweat(ctx)
-        from ally_events import try_ally_find_gold
-        await try_ally_find_gold(ctx)
+        from ally_events import try_ally_find_silver
+        await try_ally_find_silver(ctx)
         from wild_horse_events import try_wandering_horse_encounter
         await try_wandering_horse_encounter(ctx)
         from encounters.dwarf import maybe_relocate, try_steal
@@ -1382,8 +1382,8 @@ class Server:
         await self._show_room_then_encounter(ctx, level=target_level, room_no=target_room)
         from encounters.desert import try_desert_sweat
         await try_desert_sweat(ctx)
-        from ally_events import try_ally_find_gold
-        await try_ally_find_gold(ctx)
+        from ally_events import try_ally_find_silver
+        await try_ally_find_silver(ctx)
         from wild_horse_events import try_wandering_horse_encounter
         await try_wandering_horse_encounter(ctx)
         from encounters.dwarf import maybe_relocate, try_steal

--- a/server/tests/combat/test_ally_events.py
+++ b/server/tests/combat/test_ally_events.py
@@ -1,6 +1,6 @@
 """tests/test_ally_events.py
 
-Unit tests for ally_events.try_ally_find_gold.
+Unit tests for ally_events.try_ally_find_silver.
 
 Coverage:
   Guards (silent no-ops):
@@ -12,12 +12,12 @@ Coverage:
     - random roll misses → no output
 
   Happy path (random forced to hit):
-    - gold credited to player IN_HAND
-    - amount is in valid range (52-250 gp)
+    - silver credited to player IN_HAND
+    - amount is in valid range (52-250 silver)
     - 'AYF' appended to once_per_day after firing
     - player.unsaved_changes set True after firing
     - output mentions ally name
-    - output mentions gp amount
+    - output mentions silver amount
     - first ally in purchased_allies list is used (SPUR a1 priority)
     - fires exactly once even if called twice in same session (tag blocks second call)
 
@@ -31,7 +31,7 @@ import unittest
 from unittest.mock import patch, MagicMock
 
 from bar.ally_data import Ally, AllyStatus
-from ally_events import try_ally_find_gold, _OPD_ALLY_GOLD
+from ally_events import try_ally_find_silver, _OPD_ALLY_SILVER
 from base_classes import PlayerMoneyTypes
 
 
@@ -94,13 +94,13 @@ class _FakeCtx:
         return '\n'.join(self._sent)
 
 
-def _make_player(allies=None, gold=0, once_per_day=None):
+def _make_player(allies=None, silver=0, once_per_day=None):
     p = MagicMock()
     p.name = 'Rulan'
     p.once_per_day = once_per_day if once_per_day is not None else []
     p.unsaved_changes = False
 
-    wallet = {PlayerMoneyTypes.IN_HAND: gold}
+    wallet = {PlayerMoneyTypes.IN_HAND: silver}
 
     def get_silver(kind):
         return wallet.get(kind, 0)
@@ -124,32 +124,32 @@ def _run(coro):
 
 
 # ---------------------------------------------------------------------------
-# Guards — no ally gold should fire
+# Guards — no ally silver should fire
 # ---------------------------------------------------------------------------
 
-class TestAllyFindGoldGuards(unittest.IsolatedAsyncioTestCase):
+class TestAllyFindSilverGuards(unittest.IsolatedAsyncioTestCase):
 
     async def _call_always_hits(self, ctx):
         """Call with random forced to always trigger."""
         with patch('ally_events.random.random', return_value=0.0), \
              patch('ally_events.random.randint', return_value=50):
-            await try_ally_find_gold(ctx)
+            await try_ally_find_silver(ctx)
 
     async def test_no_allies_silent(self):
-        """No allies in party → no gold, no output."""
+        """No allies in party → no silver, no output."""
         player = _make_player(allies=[])
         ctx    = _FakeCtx(player)
         await self._call_always_hits(ctx)
         self.assertEqual(ctx.sent(), '')
-        self.assertNotIn(_OPD_ALLY_GOLD, player.once_per_day)
+        self.assertNotIn(_OPD_ALLY_SILVER, player.once_per_day)
 
-    async def test_free_ally_can_find_gold(self):
-        """FREE-status allies are still in the party and can find gold."""
+    async def test_free_ally_can_find_silver(self):
+        """FREE-status allies are still in the party and can find silver."""
         ally   = _make_ally(name='LYSSA', status=AllyStatus.FREE)
-        player = _make_player(allies=[ally], gold=0)
+        player = _make_player(allies=[ally], silver=0)
         ctx    = _FakeCtx(player)
         await self._call_always_hits(ctx)
-        self.assertIn(_OPD_ALLY_GOLD, player.once_per_day)
+        self.assertIn(_OPD_ALLY_SILVER, player.once_per_day)
         self.assertIn('LYSSA', ctx.sent())
 
     async def test_water_room_flag_blocks(self):
@@ -173,7 +173,7 @@ class TestAllyFindGoldGuards(unittest.IsolatedAsyncioTestCase):
     async def test_already_fired_today_blocks(self):
         """'AYF' already in once_per_day → skip."""
         ally   = _make_ally()
-        player = _make_player(allies=[ally], once_per_day=[_OPD_ALLY_GOLD])
+        player = _make_player(allies=[ally], once_per_day=[_OPD_ALLY_SILVER])
         ctx    = _FakeCtx(player)
         await self._call_always_hits(ctx)
         self.assertEqual(ctx.sent(), '')
@@ -193,49 +193,49 @@ class TestAllyFindGoldGuards(unittest.IsolatedAsyncioTestCase):
         player = _make_player(allies=[ally])
         ctx    = _FakeCtx(player)
         with patch('ally_events.random.random', return_value=1.0):
-            await try_ally_find_gold(ctx)
+            await try_ally_find_silver(ctx)
         self.assertEqual(ctx.sent(), '')
-        self.assertNotIn(_OPD_ALLY_GOLD, player.once_per_day)
+        self.assertNotIn(_OPD_ALLY_SILVER, player.once_per_day)
 
 
 # ---------------------------------------------------------------------------
-# Happy path — gold fires
+# Happy path — silver fires
 # ---------------------------------------------------------------------------
 
-class TestAllyFindGoldFires(unittest.IsolatedAsyncioTestCase):
+class TestAllyFindSilverFires(unittest.IsolatedAsyncioTestCase):
 
-    def _setup(self, ally_name='BARDA', starting_gold=100):
+    def _setup(self, ally_name='BARDA', starting_silver=100):
         ally   = _make_ally(name=ally_name)
-        player = _make_player(allies=[ally], gold=starting_gold)
+        player = _make_player(allies=[ally], silver=starting_silver)
         ctx    = _FakeCtx(player)
         return ally, player, ctx
 
     async def _fire(self, ctx, roll=50):
         with patch('ally_events.random.random', return_value=0.0), \
              patch('ally_events.random.randint', return_value=roll):
-            await try_ally_find_gold(ctx)
+            await try_ally_find_silver(ctx)
 
-    async def test_gold_credited(self):
-        """Player receives gold."""
-        _, player, ctx = self._setup(starting_gold=100)
+    async def test_silver_credited(self):
+        """Player receives silver."""
+        _, player, ctx = self._setup(starting_silver=100)
         await self._fire(ctx, roll=50)
         self.assertGreater(player._wallet[PlayerMoneyTypes.IN_HAND], 100)
 
-    async def test_gold_amount_formula(self):
-        """Amount = (roll*2)+50; roll=50 → 150 gp."""
-        _, player, ctx = self._setup(starting_gold=0)
+    async def test_silver_amount_formula(self):
+        """Amount = (roll*2)+50; roll=50 → 150 silver."""
+        _, player, ctx = self._setup(starting_silver=0)
         await self._fire(ctx, roll=50)
         self.assertEqual(player._wallet[PlayerMoneyTypes.IN_HAND], 150)
 
-    async def test_gold_min_roll(self):
-        """roll=1 → 52 gp (minimum)."""
-        _, player, ctx = self._setup(starting_gold=0)
+    async def test_silver_min_roll(self):
+        """roll=1 → 52 silver (minimum)."""
+        _, player, ctx = self._setup(starting_silver=0)
         await self._fire(ctx, roll=1)
         self.assertEqual(player._wallet[PlayerMoneyTypes.IN_HAND], 52)
 
-    async def test_gold_max_roll(self):
-        """roll=100 → 250 gp (maximum)."""
-        _, player, ctx = self._setup(starting_gold=0)
+    async def test_silver_max_roll(self):
+        """roll=100 → 250 silver (maximum)."""
+        _, player, ctx = self._setup(starting_silver=0)
         await self._fire(ctx, roll=100)
         self.assertEqual(player._wallet[PlayerMoneyTypes.IN_HAND], 250)
 
@@ -243,10 +243,10 @@ class TestAllyFindGoldFires(unittest.IsolatedAsyncioTestCase):
         """'AYF' is added to once_per_day after firing."""
         _, player, ctx = self._setup()
         await self._fire(ctx)
-        self.assertIn(_OPD_ALLY_GOLD, player.once_per_day)
+        self.assertIn(_OPD_ALLY_SILVER, player.once_per_day)
 
     async def test_unsaved_changes_set(self):
-        """player.unsaved_changes is True after gold is credited."""
+        """player.unsaved_changes is True after silver is credited."""
         _, player, ctx = self._setup()
         await self._fire(ctx)
         self.assertTrue(player.unsaved_changes)
@@ -257,8 +257,8 @@ class TestAllyFindGoldFires(unittest.IsolatedAsyncioTestCase):
         await self._fire(ctx)
         self.assertIn('LYSSA', ctx.sent())
 
-    async def test_output_mentions_gp(self):
-        """GP amount appears in output."""
+    async def test_output_mentions_silver(self):
+        """Silver amount appears in output."""
         _, _, ctx = self._setup()
         await self._fire(ctx, roll=50)
         self.assertIn('150', ctx.sent())
@@ -267,34 +267,34 @@ class TestAllyFindGoldFires(unittest.IsolatedAsyncioTestCase):
         """First SERVANT ally in party order is chosen (SPUR a1 priority)."""
         ally_a = _make_ally(name='ALAN')
         ally_b = _make_ally(name='BARDA')
-        player = _make_player(allies=[ally_a, ally_b], gold=0)
+        player = _make_player(allies=[ally_a, ally_b], silver=0)
         ctx    = _FakeCtx(player)
         with patch('ally_events.random.random', return_value=0.0), \
              patch('ally_events.random.randint', return_value=50):
-            await try_ally_find_gold(ctx)
+            await try_ally_find_silver(ctx)
         self.assertIn('ALAN', ctx.sent())
         self.assertNotIn('BARDA', ctx.sent())
 
     async def test_does_not_fire_twice(self):
         """Second call on same player is a no-op (tag blocks it)."""
-        _, player, ctx = self._setup(starting_gold=0)
+        _, player, ctx = self._setup(starting_silver=0)
         await self._fire(ctx, roll=50)
-        gold_after_first = player._wallet[PlayerMoneyTypes.IN_HAND]
+        silver_after_first = player._wallet[PlayerMoneyTypes.IN_HAND]
         ctx._sent.clear()
         await self._fire(ctx, roll=50)
-        self.assertEqual(player._wallet[PlayerMoneyTypes.IN_HAND], gold_after_first)
+        self.assertEqual(player._wallet[PlayerMoneyTypes.IN_HAND], silver_after_first)
         self.assertEqual(ctx.sent(), '')
 
     async def test_dry_room_does_not_block(self):
         """Normal dry room does not suppress the event."""
         ally   = _make_ally()
-        player = _make_player(allies=[ally], gold=0)
+        player = _make_player(allies=[ally], silver=0)
         room   = _Room(name='EAST HALL')
         ctx    = _FakeCtx(player, room=room)
         with patch('ally_events.random.random', return_value=0.0), \
              patch('ally_events.random.randint', return_value=50):
-            await try_ally_find_gold(ctx)
-        self.assertIn(_OPD_ALLY_GOLD, player.once_per_day)
+            await try_ally_find_silver(ctx)
+        self.assertIn(_OPD_ALLY_SILVER, player.once_per_day)
 
 
 # ---------------------------------------------------------------------------

--- a/server/tests/movement/test_movement.py
+++ b/server/tests/movement/test_movement.py
@@ -44,7 +44,7 @@ def test_move_broadcasts_and_changes_room():
     ctx.send      = AsyncMock()
     ctx.send_room = AsyncMock()
 
-    with patch('ally_events.try_ally_find_gold', new=AsyncMock()):
+    with patch('ally_events.try_ally_find_silver', new=AsyncMock()):
         res = asyncio.run(MoveCommand().execute(ctx, direction))
 
     assert res.success is True

--- a/server/tests/movement/test_multilevel_room_lookup.py
+++ b/server/tests/movement/test_multilevel_room_lookup.py
@@ -89,7 +89,7 @@ class TestMoveRespectsLevel(unittest.IsolatedAsyncioTestCase):
         ctx.send = AsyncMock()
         ctx.send_room = AsyncMock()
 
-        with patch('ally_events.try_ally_find_gold', new=AsyncMock()):
+        with patch('ally_events.try_ally_find_silver', new=AsyncMock()):
             await server._move(ctx, 'north')
 
         # Level 2 room 1 has a north exit to room 2; if the level-1 alias

--- a/server/tests/server/test_player_load_save.py
+++ b/server/tests/server/test_player_load_save.py
@@ -411,7 +411,7 @@ class TestPartyPersistence(unittest.TestCase):
     earlier fixes. Found live while playtesting
     encounters/ally_starvation.py: a player's allies silently vanished on
     every reconnect, so no party-dependent mechanic
-    (ally_events.try_ally_find_gold, try_hungry_ally, try_ally_death_save,
+    (ally_events.try_ally_find_silver, try_hungry_ally, try_ally_death_save,
     encounters/ally_starvation.py) could ever actually fire against a
     real, persisted ally."""
 


### PR DESCRIPTION
Follows the port's in-progress gold→silver currency rename (see CLAUDE.md) for the SERVANT-ally money-find event (SPUR `MISC6.S al.find`).

## Changes

- `try_ally_find_gold` → `try_ally_find_silver`
- `_OPD_ALLY_GOLD` → `_OPD_ALLY_SILVER` — the tag **value** `'AYF'` is unchanged; it mirrors SPUR's `*AYF` flag in `ys$`
- Player-facing text:
  - `"{ally} hands you a gold sack!"` → `"{ally} hands you a sack of silver."` (also adds the trailing period)
  - `"({amount} gp)"` → `"({amount} silver)"`
- Docstrings, comments, and the `log.exception` message updated to match
- Call sites in `simple_server.py` and the `patch(...)` targets in the movement / load-save tests updated

The separate `chance_find_gold` monster-reward flag (in `monsters.py`, `combat/rewards.py`, `encounters/turf_guards.py`) is **not** touched — out of scope for this event.

## Testing

- `tests/combat/test_ally_events.py` (18 tests) and the movement / player-load-save suites that patch the renamed function all pass.
- `pytest -q` full local run: 4375 passed, 2 skipped. The 2 failures present (`test_get_unconscious.py`, `test_give_take.py`) are pre-existing on a clean `master` (verified via `git stash`) and unrelated to this change — wording drift ("scuttles"/"skuttles", "give to which ally" prompt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)