### PR TITLE
inventory_select: shared item-selection helper for READY / UNREADY / USE / DROP

### DIFF
--- a/server/FUNCTIONS.md
+++ b/server/FUNCTIONS.md
@@ -738,9 +738,10 @@ say/shout/whisper/page — no `Command` subclass of its own, despite the name.
 ---
 
 ## inventory_select.py
-Shared "pick an item of type X" plumbing for READY/UNREADY (USE/DROP to follow):
-gather a numbered list from the player's pack plus each party ally's pack, then
-resolve a typed name or run the numbered prompt down to one choice.
+Shared "pick an item of type X" plumbing for READY, UNREADY, USE and DROP:
+gather a numbered list from the player's pack (plus each party ally's pack, for
+READY/UNREADY), then resolve a typed name or run the numbered prompt down to one
+choice.
 
 | Symbol / Function                       | Notes                                                                                         |
 |-----------------------------------------|----------------------------------------------------------------------------------------------|

--- a/server/FUNCTIONS.md
+++ b/server/FUNCTIONS.md
@@ -737,6 +737,23 @@ say/shout/whisper/page — no `Command` subclass of its own, despite the name.
 
 ---
 
+## inventory_select.py
+Shared "pick an item of type X" plumbing for READY/UNREADY (USE/DROP to follow):
+gather a numbered list from the player's pack plus each party ally's pack, then
+resolve a typed name or run the numbered prompt down to one choice.
+
+| Symbol / Function                       | Notes                                                                                         |
+|-----------------------------------------|----------------------------------------------------------------------------------------------|
+| `ItemChoice` (dataclass)                | One selectable item: `item`, `entry`, `owner` (None = player, else the Ally), `readied`; `.is_ally` / `.name` / `.owner_name` |
+| `_party_allies(player)` / `party_allies` | Living party allies in party order (moved here from commands/ready.py)                        |
+| `same_item(a, b)`                        | Pure — identity, then `id_number` *within the same category*                                  |
+| `owner_has_readied(owner, item)`         | Pure — is `item` the weapon `owner` (player or Ally) has readied                              |
+| `gather_items(player, *, category=, predicate=, include_player=, include_allies=, allies=)` | Numbered `list[ItemChoice]`; player's pack first, then each ally's, grouped by ally |
+| `resolve_or_prompt(ctx, choices, *, args, prompt_text, label_fn, match_fn=, group_fn=, list_header=, ambiguous_header=, no_match_msg=, invalid_msg=, auto_select_single=)` | async — name match or numbered menu → one `ItemChoice` or `None` (empty/no-match/cancel/bad-input) |
+| `choices_menu(choices, label_fn, *, header=)` | Pure — a flat numbered menu block (list of lines for `ctx.send`)                          |
+
+---
+
 ## item_system.py
 Weapon and item data layer: loading from JSON, class/race bonuses, async display helpers.
 

--- a/server/commands/drop.py
+++ b/server/commands/drop.py
@@ -22,6 +22,7 @@ from commands.base_command import Command, CommandResult, Mode
 from commands.help import Help, HelpCategory
 from flags import PlayerFlags
 from inventory import InventoryEntry
+from inventory_select import gather_items, resolve_or_prompt
 from network_context import GameContext
 
 _RING_ID = 67  # ring of invisibility (objects.json) -- see commands/wear.py
@@ -158,68 +159,28 @@ class DropCommand(Command):
             await ctx.send('You are carrying nothing.')
             return CommandResult.ok()
 
-        entries = inventory.entries()
-        if not entries:
+        # Name match, ambiguous "Which one?" sub-prompt, or the full
+        # numbered inventory list -- all via the shared picker
+        # (inventory_select). Every category is droppable, so no filter.
+        choices = gather_items(player)
+        if not choices:
             await ctx.send('You are carrying nothing.')
             return CommandResult.ok()
 
-        # Name/pattern given — find matching entries
-        if args:
-            pattern = ' '.join(args).lower()
-            matches = [(i, e) for i, e in enumerate(entries)
-                       if pattern in getattr(e.item, 'name', '').lower()]
-            if not matches:
-                await ctx.send(f'You are not carrying anything matching "{" ".join(args)}".')
-                return CommandResult.ok()
-            if len(matches) == 1:
-                choice = matches[0][0]
-            else:
-                # Ambiguous — show the matches and ask
-                lines = ['Which one?', '']
-                for i, (orig_idx, e) in enumerate(matches, 1):
-                    name = getattr(e.item, 'name', '?')
-                    qty  = f' x{e.quantity}' if e.quantity > 1 else ''
-                    lines.append(f'  {i:>2}. {name}{qty}')
-                lines.append('')
-                await ctx.send(lines)
-                raw = await ctx.prompt(preamble_lines=f'(1-{len(matches)}, or {ctx.player.return_key} to cancel)',
-                                       prompt_text="Drop which")
-                if not raw or not raw.strip():
-                    return CommandResult.ok()
-                try:
-                    pick = int(raw.strip()) - 1
-                    if not (0 <= pick < len(matches)):
-                        raise ValueError
-                except ValueError:
-                    await ctx.send('Invalid selection.')
-                    return CommandResult.ok()
-                choice = matches[pick][0]
+        def _label(c) -> str:
+            qty = getattr(c.entry, 'quantity', 1) or 1
+            return f'{c.name}{f" x{qty}" if qty > 1 else ""}'
 
-        else:
-            # No args — show full inventory and prompt
-            lines = ['You are carrying:', '']
-            for i, entry in enumerate(entries, 1):
-                name = getattr(entry.item, 'name', '?')
-                qty  = f' x{entry.quantity}' if entry.quantity > 1 else ''
-                lines.append(f'  {i:>2}. {name}{qty}')
-            lines.append('')
-            await ctx.send(lines)
-
-            raw = await ctx.prompt(preamble_lines=f'(1-{len(entries)}, or {ctx.player.return_key} to cancel)',
-                                   prompt_text="Drop which item")
-            if not raw or not raw.strip():
-                return CommandResult.ok()
-            try:
-                choice = int(raw.strip()) - 1
-            except ValueError:
-                await ctx.send('Invalid selection.')
-                return CommandResult.ok()
-
-        if not (0 <= choice < len(entries)):
-            await ctx.send(f'You are not carrying item {choice + 1}.')
+        choice = await resolve_or_prompt(
+            ctx, choices, args=args, prompt_text='Drop which item',
+            label_fn=_label,
+            list_header='You are carrying:',
+            no_match_msg=lambda q: f'You are not carrying anything matching "{q}".',
+        )
+        if choice is None:
             return CommandResult.ok()
 
-        entry = entries[choice]
+        entry = choice.entry
         name  = getattr(entry.item, 'name', '?')
 
         # Ring of invisibility (#67): can't drop it while worn (SPUR.MISC.S:136/

--- a/server/commands/give.py
+++ b/server/commands/give.py
@@ -438,8 +438,9 @@ class GiveCommand(Command):
             # changed hands (they might already be wielding something they
             # prefer, or the player may be handing over a spare). The
             # player now decides who wields what, and when, via READY,
-            # which lists allies' carried weapons (commands/ready.py's
-            # _ally_weapon_entries / _toggle_ally_weapon).
+            # which lists allies' carried weapons (inventory_select.
+            # gather_items(include_allies=True) / ready.py's
+            # _toggle_ally_weapon).
             from items import Weapon
             from bar.ally_data import add_ally_item
             if isinstance(item, Weapon):

--- a/server/commands/ready.py
+++ b/server/commands/ready.py
@@ -15,6 +15,11 @@ from base_classes import PlayerClass, PlayerStat
 from combat.resolution import tier_label as _tier_label
 from commands.base_command import Command, CommandResult, Mode
 from commands.help import Help, HelpCategory
+from inventory_select import (
+    gather_items,
+    owner_has_readied,
+    resolve_or_prompt,
+)
 from item_system import weapon_bonus
 from items import ItemCategory
 from network_context import GameContext
@@ -57,56 +62,16 @@ def _find_storm_in_inventory(player, excluding_id=None):
     return None
 
 
-def _weapon_entries(player):
-    """Return InventoryEntry list for weapons the player carries."""
-    inv = getattr(player, 'inventory', None)
-    if inv is None:
-        return []
-    return inv.entries(category=str(ItemCategory.WEAPON))
-
-
 def _stat(player, key) -> int:
     stats = getattr(player, 'stats', {}) or {}
     return int(stats.get(key, 0) or 0)
 
 
-def _party_allies(player):
-    """Living party allies, in party order.
-
-    Alpha-tester feedback: it made no sense for an ally to *automatically*
-    ready a weapon the moment it was GIVEn to them (commands/give.py used
-    to do exactly that). READY now also lists every weapon sitting in an
-    ally's pack (bar/ally_data.py Ally.items) so the player decides who
-    wields what, and when -- see _ally_weapon_entries() below.
-    """
-    party = getattr(player, 'party', None)
-    if not party:
-        return []
-    try:
-        from bar.ally_data import Ally, AllyStatus
-    except ImportError:
-        return []
-    out = []
-    for m in getattr(party, 'members', None) or []:
-        if not isinstance(m, Ally):
-            continue
-        if getattr(m, 'status', None) == AllyStatus.DEAD:
-            continue
-        out.append(m)
-    return out
-
-
-def _ally_weapon_entries(player):
-    """[(ally, InventoryEntry)] for every weapon in each party ally's pack."""
-    result = []
-    for ally in _party_allies(player):
-        for entry in getattr(ally, 'items', None) or []:
-            item = getattr(entry, 'item', None)
-            if item is None:
-                continue
-            if str(getattr(item, 'category', '')) == str(ItemCategory.WEAPON):
-                result.append((ally, entry))
-    return result
+# _party_allies() / the ally-weapon walk / the readied-match test all moved
+# to inventory_select.py so READY and UNREADY share one copy. gather_items(
+# category=WEAPON, include_allies=True) returns the combined list; each
+# ItemChoice carries .owner (None => the player, else the Ally) and
+# .readied.
 
 
 def _weapon_needs_ammo(item) -> bool:
@@ -140,15 +105,10 @@ def _matching_ammo_in_inventory(player, weapon):
     return None
 
 
-def _ally_has_readied(ally, item) -> bool:
-    """True if *item* is the weapon *ally* currently has readied."""
-    cur = getattr(ally, 'readied_weapon', None)
-    if cur is None:
-        return False
-    if cur is item:
-        return True
-    cur_id, item_id = getattr(cur, 'id_number', None), getattr(item, 'id_number', None)
-    return cur_id is not None and cur_id == item_id
+# _ally_has_readied(ally, item) is now inventory_select.owner_has_readied
+# (same identity-then-id_number-within-category test, generalised to the
+# player too).
+_ally_has_readied = owner_has_readied
 
 
 async def _toggle_ally_weapon(ctx, player, ally, item) -> CommandResult:
@@ -245,11 +205,15 @@ class ReadyCommand(Command):
 
     async def execute(self, ctx: GameContext, *args) -> CommandResult:
         args, _switches = self.parse_args(*args)
-        player  = ctx.player
-        entries = _weapon_entries(player)
-        ally_entries = _ally_weapon_entries(player)   # [(ally, InventoryEntry)]
+        player = ctx.player
 
-        if not entries and not ally_entries:
+        # The player's own weapons plus every weapon in each party ally's
+        # pack, one combined numbered list (inventory_select.gather_items).
+        choices     = gather_items(player, category=ItemCategory.WEAPON,
+                                   include_allies=True)
+        has_ally    = any(c.is_ally for c in choices)
+
+        if not choices:
             await ctx.send('You have no weapons to ready.')
             return CommandResult.ok()
 
@@ -257,93 +221,44 @@ class ReadyCommand(Command):
         # here when there's nothing but the player's own weapons to offer
         # (an ally weapon is still readiable below regardless of the
         # player's Strength).
-        if not ally_entries and _stat(player, PlayerStat.STR) < _MIN_STR:
+        if not has_ally and _stat(player, PlayerStat.STR) < _MIN_STR:
             await ctx.send('Not enough strength to ready a weapon!')
             return CommandResult.ok()
 
-        def _ally_label(ally, e) -> str:
-            wname = getattr(e.item, 'name', '?')
-            tag   = '  (readied)' if _ally_has_readied(ally, e.item) else ''
-            return f'{ally.name}: {wname}{tag}'
+        def _label(c) -> str:
+            if c.is_ally:
+                tag = '  (readied)' if c.readied else ''
+                return f'{c.owner.name}: {c.name}{tag}'
+            wc     = getattr(c.item, 'weapon_class', None)
+            wc_str = (wc.value if hasattr(wc, 'value') else str(wc)) if wc else ''
+            vp     = _battle_exp(player, c.item)
+            return f'{c.name:<22} {wc_str:<18} {_tier_label(vp)}'
 
-        # Resolve the target: one of the player's own weapon entries, or an
-        # (ally, entry) pair. Picking an ally's weapon toggles that ally's
-        # readied weapon and returns straight away -- the player-side
-        # readying flow below only runs for the player's own weapons.
-        if args:
-            pattern = ' '.join(args).lower()
-            p_matches = [e for e in entries
-                         if pattern in (getattr(e.item, 'name', '') or '').lower()]
-            a_matches = [(ally, e) for (ally, e) in ally_entries
-                         if pattern in (getattr(e.item, 'name', '') or '').lower()
-                         or pattern in ally.name.lower()]
-            combined = [('p', e) for e in p_matches] + [('a', pair) for pair in a_matches]
-            if not combined:
-                await ctx.send(f'No weapon or ally matching "{" ".join(args)}".')
-                return CommandResult.ok()
-            if len(combined) == 1:
-                kind, obj = combined[0]
-                if kind == 'a':
-                    return await _toggle_ally_weapon(ctx, player, obj[0], obj[1].item)
-                entry = obj
-            else:
-                lines = ['Which weapon?', '']
-                for n, (kind, obj) in enumerate(combined, 1):
-                    if kind == 'p':
-                        lines.append(f'  {n:>2}. {getattr(obj.item, "name", "?")}')
-                    else:
-                        lines.append(f'  {n:>2}. {_ally_label(obj[0], obj[1])}')
-                lines.append('')
-                await ctx.send(lines)
-                raw = await ctx.prompt(preamble_lines=f'(1-{len(combined)}, {ctx.player.return_key} to cancel)',
-                                       prompt_text="Ready which")
-                if not raw or not raw.strip():
-                    return CommandResult.ok()
-                try:
-                    pick = int(raw.strip()) - 1
-                    if not (0 <= pick < len(combined)):
-                        raise ValueError
-                except ValueError:
-                    await ctx.send('Invalid selection.')
-                    return CommandResult.ok()
-                kind, obj = combined[pick]
-                if kind == 'a':
-                    return await _toggle_ally_weapon(ctx, player, obj[0], obj[1].item)
-                entry = obj
-        else:
-            lines = []
-            if entries:
-                lines += ['Weapons you carry:', '']
-                for i, e in enumerate(entries, 1):
-                    name    = getattr(e.item, 'name', '?')
-                    wc      = getattr(e.item, 'weapon_class', None)
-                    wc_str  = (wc.value if hasattr(wc, 'value') else str(wc)) if wc else ''
-                    vp      = _battle_exp(player, e.item)
-                    badge   = _tier_label(vp)
-                    lines.append(f'  {i:>2}. {name:<22} {wc_str:<18} {badge}')
-                lines.append('')
-            if ally_entries:
-                lines += ["Your allies' weapons:", '']
-                for j, (ally, e) in enumerate(ally_entries, len(entries) + 1):
-                    lines.append(f'  {j:>2}. {_ally_label(ally, e)}')
-                lines.append('')
-            total = len(entries) + len(ally_entries)
-            await ctx.send(lines)
-            raw = await ctx.prompt(preamble_lines=f'(1-{total}, {ctx.player.return_key} to cancel)',
-                                   prompt_text="Ready which weapon")
-            if not raw or not raw.strip():
-                return CommandResult.ok()
-            try:
-                choice = int(raw.strip()) - 1
-                if not (0 <= choice < total):
-                    raise ValueError
-            except ValueError:
-                await ctx.send('Invalid selection.')
-                return CommandResult.ok()
-            if choice >= len(entries):
-                ally, e = ally_entries[choice - len(entries)]
-                return await _toggle_ally_weapon(ctx, player, ally, e.item)
-            entry = entries[choice]
+        def _match(c, pattern) -> bool:
+            if pattern in (c.name or '').lower():
+                return True
+            return c.is_ally and pattern in c.owner.name.lower()
+
+        # Resolve to one weapon (the player's, or an ally's). Picking an
+        # ally's weapon toggles that ally's readied weapon and returns
+        # straight away -- the player-side readying flow below only runs
+        # for the player's own weapons. The bare list keeps its two
+        # labelled sections ("Weapons you carry:" / "Your allies'
+        # weapons:"); a name narrowed to several shows a flat "Which
+        # weapon?" list.
+        choice = await resolve_or_prompt(
+            ctx, choices, args=args, prompt_text='Ready which weapon',
+            label_fn=_label, match_fn=_match,
+            group_fn=(lambda c: "Your allies' weapons:" if c.is_ally
+                      else 'Weapons you carry:'),
+            ambiguous_header='Which weapon?',
+            no_match_msg=lambda q: f'No weapon or ally matching "{q}".',
+        )
+        if choice is None:
+            return CommandResult.ok()
+        if choice.is_ally:
+            return await _toggle_ally_weapon(ctx, player, choice.owner, choice.item)
+        entry = choice.entry
 
         # From here on the player is readying one of their *own* weapons.
         str_val = _stat(player, PlayerStat.STR)

--- a/server/commands/unready.py
+++ b/server/commands/unready.py
@@ -17,6 +17,7 @@ player with only their own weapon readied keeps SPUR's direct repack.
 """
 from commands.base_command import Command, CommandResult, Mode
 from commands.help import Help, HelpCategory
+from inventory_select import ItemChoice, party_allies, resolve_or_prompt
 from network_context import GameContext
 
 
@@ -102,9 +103,8 @@ class UnreadyCommand(Command):
             return CommandResult.ok()
 
         # Bare UNREADY. Gather every readied weapon in the party.
-        from commands.ready import _party_allies
         own = getattr(player, 'readied_weapon', None)
-        ally_readied = [(a, w) for a in _party_allies(player)
+        ally_readied = [(a, w) for a in party_allies(player)
                         if (w := getattr(a, 'readied_weapon', None)) is not None]
 
         # No ally is wielding anything -- unchanged SPUR behaviour.
@@ -115,33 +115,22 @@ class UnreadyCommand(Command):
             return await _repack_player(ctx, player, own)
 
         # An ally has a weapon readied: offer the list (player's own first,
-        # if any, then each ally's). One candidate needs no menu.
-        candidates = ([('p', None, own)] if own is not None else [])
-        candidates += [('a', a, w) for (a, w) in ally_readied]
+        # if any, then each ally's) via the shared numbered-pick helper.
+        # A lone candidate needs no menu -- resolve_or_prompt() returns it
+        # outright.
+        choices = ([ItemChoice(item=own, owner=None, readied=True)]
+                   if own is not None else [])
+        choices += [ItemChoice(item=w, owner=a, readied=True)
+                    for (a, w) in ally_readied]
 
-        if len(candidates) == 1:
-            _, a, w = candidates[0]
-            return await _repack_ally(ctx, player, a, w)
-
-        lines = ['Weapons readied:', '']
-        for n, (kind, a, w) in enumerate(candidates, 1):
-            who = 'You' if kind == 'p' else a.name
-            lines.append(f'  {n:>2}. {who}: {getattr(w, "name", "?")}')
-        lines.append('')
-        await ctx.send(lines)
-        return_key = getattr(player, 'return_key', 'RETURN')
-        raw = await ctx.prompt(preamble_lines=f'(1-{len(candidates)}, {return_key} to cancel)',
-                               prompt_text='Unready which')
-        if not raw or not raw.strip():
+        choice = await resolve_or_prompt(
+            ctx, choices, args=[], prompt_text='Unready which',
+            label_fn=lambda c: f'{c.owner_name}: {c.name}',
+            list_header='Weapons readied:',
+            auto_select_single=True,
+        )
+        if choice is None:
             return CommandResult.ok()
-        try:
-            pick = int(raw.strip()) - 1
-            if not (0 <= pick < len(candidates)):
-                raise ValueError
-        except ValueError:
-            await ctx.send('Invalid selection.')
-            return CommandResult.ok()
-        kind, a, w = candidates[pick]
-        if kind == 'p':
-            return await _repack_player(ctx, player, w)
-        return await _repack_ally(ctx, player, a, w)
+        if choice.is_ally:
+            return await _repack_ally(ctx, player, choice.owner, choice.item)
+        return await _repack_player(ctx, player, choice.item)

--- a/server/commands/use.py
+++ b/server/commands/use.py
@@ -40,6 +40,7 @@ from typing import Optional
 
 from commands.base_command import Command, CommandResult, Mode
 from commands.help import Help, HelpCategory
+from inventory_select import gather_items, resolve_or_prompt
 from item_system import ItemType
 from items import Item, ItemCategory
 from network_context import GameContext
@@ -359,13 +360,10 @@ async def _communicator_malfunction(ctx, player) -> None:
     await ctx.server._teleport_to(ctx, target_level, target_room)
 
 
-def _usable_entries(player):
-    """Return inventory entries that are not weapons (weapons use `ready`)."""
-    inv = getattr(player, 'inventory', None)
-    if inv is None:
-        return []
-    weapon_cat = str(ItemCategory.WEAPON)
-    return [e for e in inv.entries() if str(getattr(e.item, 'category', '')) != weapon_cat]
+def _not_a_weapon(item) -> bool:
+    """USE covers everything READY doesn't -- weapons are readied, not used.
+    Passed to inventory_select.gather_items() as its predicate."""
+    return str(getattr(item, 'category', '')) != str(ItemCategory.WEAPON)
 
 
 class UseCommand(Command):
@@ -426,41 +424,26 @@ class UseCommand(Command):
                     player.hit_points = hp + 4
             return CommandResult.ok()
 
-        entries = _usable_entries(player)
+        choices = gather_items(player, predicate=_not_a_weapon)
 
-        if not entries:
+        if not choices:
             await ctx.send('You have nothing to use.')
             return CommandResult.ok()
 
-        # Resolve by name arg or interactive prompt
-        if args:
-            pattern = ' '.join(args).lower()
-            matches = [e for e in entries
-                       if pattern in (getattr(e.item, 'name', '') or '').lower()]
-            if not matches:
-                await ctx.send(f'You are not carrying anything matching "{" ".join(args)}".')
-                return CommandResult.ok()
-            entry = matches[0]
-        else:
-            lines = ['', 'Items:']
-            for i, e in enumerate(entries, 1):
-                lines.append(f'  {i:>2}. {getattr(e.item, "name", "?")}')
-            lines.append('')
-            await ctx.send(lines)
-            raw = await ctx.prompt(preamble_lines=f'(1-{len(entries)}, {ctx.player.return_key} to cancel)',
-                                   prompt_text="Use which item")
-            if not raw or not raw.strip():
-                return CommandResult.ok()
-            try:
-                idx = int(raw.strip()) - 1
-                if not (0 <= idx < len(entries)):
-                    raise ValueError
-            except ValueError:
-                await ctx.send("You don't have that item.")
-                return CommandResult.ok()
-            entry = entries[idx]
+        # Name match, or the numbered "Items:" menu -- via the shared
+        # picker (inventory_select). Naming several items now narrows with
+        # a "Which one?" sub-prompt instead of silently USEing the first.
+        choice = await resolve_or_prompt(
+            ctx, choices, args=args, prompt_text='Use which item',
+            label_fn=lambda c: c.name,
+            list_header='Items:',
+            no_match_msg=lambda q: f'You are not carrying anything matching "{q}".',
+            invalid_msg="You don't have that item.",
+        )
+        if choice is None:
+            return CommandResult.ok()
 
-        item     = entry.item
+        item     = choice.item
         item_no  = getattr(item, 'number', None) or getattr(item, 'id_number', None)
         item_cat = getattr(item, 'category', None)
 

--- a/server/inventory_select.py
+++ b/server/inventory_select.py
@@ -1,0 +1,313 @@
+"""inventory_select.py — shared "pick an item of type X" plumbing.
+
+Several commands (READY/UNREADY, and — as they migrate — USE/DROP/GIVE/…)
+all do the same two-step dance:
+
+  1. Gather a numbered list of the items a player can act on — sometimes
+     just their own pack, sometimes their pack *plus* every party ally's
+     pack (READY lets the player direct an ally's weapon; UNREADY mirrors
+     it).
+  2. Resolve a name the player typed, or run an interactive numbered
+     prompt, down to exactly one of those items — with the same
+     empty/one-match/ambiguous/cancel/bad-input handling every time.
+
+This module factors both steps out. `gather_items()` is step 1;
+`resolve_or_prompt()` is step 2. The command keeps all the domain logic
+(STR gates, STORM-weapon tantrums, water rooms, …) — it just stops
+re-implementing the list and the menu.
+
+`_party_allies()` moved here from commands/ready.py so both READY and
+UNREADY import it from one place.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+from items import ItemCategory
+
+
+# ---------------------------------------------------------------------------
+# Party allies
+# ---------------------------------------------------------------------------
+
+def _party_allies(player) -> list:
+    """Living party allies, in party order.
+
+    Alpha-tester feedback: it made no sense for an ally to *automatically*
+    ready a weapon the moment it was GIVEn to them (commands/give.py used
+    to do exactly that). READY now also lists every weapon sitting in an
+    ally's pack (bar/ally_data.py Ally.items) so the player decides who
+    wields what, and when -- see gather_items(include_allies=True).
+    """
+    party = getattr(player, 'party', None)
+    if not party:
+        return []
+    try:
+        from bar.ally_data import Ally, AllyStatus
+    except ImportError:
+        return []
+    out = []
+    for m in getattr(party, 'members', None) or []:
+        if not isinstance(m, Ally):
+            continue
+        if getattr(m, 'status', None) == AllyStatus.DEAD:
+            continue
+        out.append(m)
+    return out
+
+
+# Backwards-friendly public alias.
+party_allies = _party_allies
+
+
+# ---------------------------------------------------------------------------
+# ItemChoice
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ItemChoice:
+    """One selectable item, plus who owns it.
+
+    owner is None for the player's own item, or the Ally who carries it.
+    entry is the InventoryEntry the item came from when there is one
+    (the player's Inventory, or an ally's `.items` list); it may be None
+    for choices built straight from an item object (e.g. UNREADY's list of
+    already-readied weapons). item is always the item object itself.
+    """
+    item: object
+    entry: object = None
+    owner: object = None
+    readied: bool = False
+
+    @property
+    def is_ally(self) -> bool:
+        return self.owner is not None
+
+    @property
+    def name(self) -> str:
+        return getattr(self.item, 'name', '?') or '?'
+
+    @property
+    def owner_name(self) -> str:
+        return getattr(self.owner, 'name', 'You') if self.owner is not None else 'You'
+
+
+def same_item(a, b) -> bool:
+    """True if *a* and *b* are the same item.
+
+    Identity first, then id_number *within the same category* -- id_number
+    is only unique per category (weapons/items/rations each number from 1;
+    items.py:364), so an id-only compare would conflate weapon #17 with
+    ration #17.
+    """
+    if a is b:
+        return True
+    if a is None or b is None:
+        return False
+    a_id, b_id = getattr(a, 'id_number', None), getattr(b, 'id_number', None)
+    if a_id is None or a_id != b_id:
+        return False
+    return str(getattr(a, 'category', '')) == str(getattr(b, 'category', ''))
+
+
+def owner_has_readied(owner, item) -> bool:
+    """True if *item* is the weapon *owner* (player or Ally) has readied."""
+    return same_item(getattr(owner, 'readied_weapon', None), item)
+
+
+# ---------------------------------------------------------------------------
+# gather_items -- step 1
+# ---------------------------------------------------------------------------
+
+def _matches(item, category, predicate) -> bool:
+    if category is not None and str(getattr(item, 'category', '')) != str(category):
+        return False
+    if predicate is not None and not predicate(item):
+        return False
+    return True
+
+
+def gather_items(
+    player,
+    *,
+    category: Optional[str] = None,
+    predicate: Optional[Callable[[object], bool]] = None,
+    include_player: bool = True,
+    include_allies: bool = False,
+    allies: Optional[list] = None,
+) -> list[ItemChoice]:
+    """Return a numbered (by list position) list of ItemChoice.
+
+    category   -- an ItemCategory (or its str) to keep; None keeps every
+                  category.
+    predicate  -- optional extra test, ANDed with *category*.
+    include_player  -- include the player's own pack (default True).
+    include_allies  -- also walk each living party ally's `.items`.
+    allies     -- override the ally list (defaults to _party_allies()).
+
+    Order: the player's own items first (inventory order), then each
+    ally's items grouped by ally in party order -- the layout bare READY
+    has shown since the ally-weapon feature landed.
+    """
+    out: list[ItemChoice] = []
+
+    if include_player:
+        inv = getattr(player, 'inventory', None)
+        if inv is not None:
+            for e in inv.entries():
+                item = getattr(e, 'item', None)
+                if item is None or not _matches(item, category, predicate):
+                    continue
+                out.append(ItemChoice(
+                    item=item, entry=e, owner=None,
+                    readied=owner_has_readied(player, item),
+                ))
+
+    if include_allies:
+        for ally in (allies if allies is not None else _party_allies(player)):
+            for e in getattr(ally, 'items', None) or []:
+                item = getattr(e, 'item', None)
+                if item is None or not _matches(item, category, predicate):
+                    continue
+                out.append(ItemChoice(
+                    item=item, entry=e, owner=ally,
+                    readied=owner_has_readied(ally, item),
+                ))
+
+    return out
+
+
+# ---------------------------------------------------------------------------
+# resolve_or_prompt -- step 2
+# ---------------------------------------------------------------------------
+
+_UNSET = object()
+
+
+def _default_match(choice: ItemChoice, pattern: str) -> bool:
+    return pattern in (choice.name or '').lower()
+
+
+async def resolve_or_prompt(
+    ctx,
+    choices: list[ItemChoice],
+    *,
+    args,
+    prompt_text: str,
+    label_fn: Callable[[ItemChoice], str],
+    match_fn: Optional[Callable[[ItemChoice, str], bool]] = None,
+    group_fn: Optional[Callable[[ItemChoice], str]] = None,
+    list_header: Optional[str] = None,
+    ambiguous_header: str = 'Which one?',
+    no_match_msg: Optional[Callable[[str], str]] = None,
+    invalid_msg: str = 'Invalid selection.',
+    auto_select_single: bool = False,
+) -> Optional[ItemChoice]:
+    """Resolve *choices* down to one, by name or by numbered prompt.
+
+    args        -- the raw command args; when non-empty they're joined and
+                   matched (case-insensitive, substring) against each
+                   choice via *match_fn*.
+    label_fn    -- choice -> the menu text after the "NN. " number.
+    match_fn    -- choice, lowercased-pattern -> bool. Default: substring
+                   match on the item name.
+    group_fn    -- choice -> a section header. When given, the *full* list
+                   (no name typed) is split into sections, each with its
+                   header and a blank line, numbered continuously. The
+                   narrowed-by-name list is always shown flat under
+                   *ambiguous_header*.
+    list_header -- header for the full flat list (ignored when *group_fn*
+                   is set). None => no header line.
+    no_match_msg -- pattern -> the "nothing matches" line. Default:
+                   'Nothing matching "<pattern>".'
+    auto_select_single -- when the list holds exactly one choice and no
+                   name was typed, return it without drawing a menu
+                   (UNREADY does this; bare READY still shows its one-line
+                   menu).
+
+    Returns the chosen ItemChoice, or None on: empty *choices*, no name
+    match, ambiguous cancel, blank prompt (cancel), or bad input. A
+    player-facing line is sent for every None case except a deliberate
+    blank-line cancel.
+    """
+    if not choices:
+        return None
+
+    match_fn = match_fn or _default_match
+    return_key = getattr(getattr(ctx, 'player', None), 'return_key', 'RETURN')
+
+    # --- name given: filter, then 0/1/many ---------------------------------
+    if args:
+        pattern = ' '.join(args).lower()
+        matches = [c for c in choices if match_fn(c, pattern)]
+        if not matches:
+            msg = (no_match_msg or (lambda q: f'Nothing matching "{q}".'))(' '.join(args))
+            await ctx.send(msg)
+            return None
+        if len(matches) == 1:
+            return matches[0]
+        menu = choices_menu(matches, label_fn, header=ambiguous_header)
+        await ctx.send(menu)
+        return await _prompt_pick(ctx, matches, prompt_text, return_key, invalid_msg)
+
+    # --- no name: the full list -----------------------------------------
+    if auto_select_single and len(choices) == 1:
+        return choices[0]
+
+    if group_fn is not None:
+        lines: list[str] = []
+        n = 0
+        last_key = _UNSET
+        for c in choices:
+            key = group_fn(c)
+            if key != last_key:
+                if lines:
+                    lines.append('')
+                lines.append(key)
+                lines.append('')
+                last_key = key
+            n += 1
+            lines.append(f'  {n:>2}. {label_fn(c)}')
+        lines.append('')
+        await ctx.send(lines)
+    else:
+        await ctx.send(choices_menu(choices, label_fn, header=list_header))
+
+    return await _prompt_pick(ctx, choices, prompt_text, return_key, invalid_msg)
+
+
+def choices_menu(
+    choices: list[ItemChoice],
+    label_fn: Callable[[ItemChoice], str],
+    *,
+    header: Optional[str] = None,
+) -> list[str]:
+    """A flat numbered menu block: optional header, blank, "  NN. label"
+    rows, trailing blank. Matches the shape ctx.send() expects (one list
+    element per line)."""
+    lines: list[str] = []
+    if header:
+        lines += [header, '']
+    for i, c in enumerate(choices, 1):
+        lines.append(f'  {i:>2}. {label_fn(c)}')
+    lines.append('')
+    return lines
+
+
+async def _prompt_pick(ctx, choices, prompt_text, return_key, invalid_msg):
+    """Prompt "(1-N, <key> to cancel)" and map the reply to a choice."""
+    raw = await ctx.prompt(
+        preamble_lines=f'(1-{len(choices)}, {return_key} to cancel)',
+        prompt_text=prompt_text,
+    )
+    if not raw or not raw.strip():
+        return None
+    try:
+        pick = int(raw.strip()) - 1
+        if not (0 <= pick < len(choices)):
+            raise ValueError
+    except ValueError:
+        await ctx.send(invalid_msg)
+        return None
+    return choices[pick]

--- a/server/inventory_select.py
+++ b/server/inventory_select.py
@@ -121,6 +121,10 @@ def owner_has_readied(owner, item) -> bool:
 # ---------------------------------------------------------------------------
 
 def _matches(item, category, predicate) -> bool:
+    """True when *item* clears both filters. Each is optional and each can
+    only ever *exclude* an item, so they combine as a plain logical AND --
+    pass both, or the filter simply wasn't supplied. (Nothing bitwise
+    here; it's two `if ...: return False` gates.)"""
     if category is not None and str(getattr(item, 'category', '')) != str(category):
         return False
     if predicate is not None and not predicate(item):
@@ -141,7 +145,19 @@ def gather_items(
 
     category   -- an ItemCategory (or its str) to keep; None keeps every
                   category.
-    predicate  -- optional extra test, ANDed with *category*.
+    predicate  -- an optional `callable(item) -> bool` used as a *second
+                  filter*, on top of *category*. An item survives only if
+                  it clears both tests -- a plain `and`, not a bitwise
+                  operation. This is the parameter to reach for whenever
+                  the thing you're selecting on isn't a category:
+                    * USE wants "everything that isn't a weapon"
+                      (`predicate=_not_a_weapon`, no category at all);
+                    * a name substring -- `lambda it: 'BOW' in it.name`;
+                    * an id range, a flag check ("has ammo loaded"),
+                      "worth more than N silver", and so on.
+                  `None` (the default) means no second filter. Passing
+                  *only* a predicate and leaving *category* as None is a
+                  normal call -- that's how USE uses it.
     include_player  -- include the player's own pack (default True).
     include_allies  -- also walk each living party ally's `.items`.
     allies     -- override the ally list (defaults to _party_allies()).

--- a/server/tests/test_inventory_select.py
+++ b/server/tests/test_inventory_select.py
@@ -1,0 +1,279 @@
+"""tests/test_inventory_select.py
+
+Unit tests for inventory_select.py -- the shared "pick an item of type X"
+helper that READY / UNREADY (and, later, USE / DROP) build their numbered
+lists and selection prompts on.
+
+Run with:
+    python -m pytest tests/test_inventory_select.py -v
+"""
+from __future__ import annotations
+
+import unittest
+
+from inventory import Inventory
+from inventory_select import (
+    ItemChoice,
+    gather_items,
+    owner_has_readied,
+    resolve_or_prompt,
+    same_item,
+)
+from items import Item, ItemCategory
+
+
+def _weapon(name, item_id=1):
+    return Item(id_number=item_id, name=name, category=ItemCategory.WEAPON)
+
+
+def _thing(name, item_id=1):
+    return Item(id_number=item_id, name=name, category=ItemCategory.ITEM)
+
+
+class _FakeAlly:
+    def __init__(self, name, items=None, readied_weapon=None):
+        self.name = name
+        self.items = list(items or [])
+        self.readied_weapon = readied_weapon
+        self.status = None
+
+
+class _FakeParty:
+    def __init__(self, members):
+        self.members = members
+
+
+class _FakePlayer:
+    def __init__(self, items=None, readied_weapon=None, party=None):
+        self.inventory = Inventory()
+        for it in (items or []):
+            self.inventory.add(it)
+        self.readied_weapon = readied_weapon
+        self.party = party
+        self.return_key = 'RETURN'
+
+
+class _FakeCtx:
+    def __init__(self, player, answers=()):
+        self.player = player
+        self._sent: list[str] = []
+        self._answers = iter(answers)
+
+    async def send(self, msg, **kw):
+        if isinstance(msg, list):
+            self._sent.extend(str(m) for m in msg)
+        else:
+            self._sent.append(str(msg))
+
+    async def prompt(self, *a, **kw):
+        return next(self._answers, None)
+
+    def sent(self):
+        return '\n'.join(self._sent)
+
+
+# ---------------------------------------------------------------------------
+# same_item / owner_has_readied
+# ---------------------------------------------------------------------------
+
+class TestSameItem(unittest.TestCase):
+    def test_identity(self):
+        w = _weapon('SWORD')
+        self.assertTrue(same_item(w, w))
+
+    def test_same_id_same_category(self):
+        self.assertTrue(same_item(_weapon('SWORD', 5), _weapon('SWORD', 5)))
+
+    def test_same_id_different_category_is_not_a_match(self):
+        # id_number is only unique within a category (weapons/items/rations
+        # each count from 1) -- weapon #5 must not equal item #5.
+        self.assertFalse(same_item(_weapon('SWORD', 5), _thing('POTION', 5)))
+
+    def test_none(self):
+        self.assertFalse(same_item(None, _weapon('SWORD')))
+
+    def test_owner_has_readied(self):
+        w = _weapon('AXE', 9)
+        ally = _FakeAlly('Alan', readied_weapon=_weapon('AXE', 9))
+        self.assertTrue(owner_has_readied(ally, w))
+        self.assertFalse(owner_has_readied(_FakeAlly('Bo'), w))
+
+
+# ---------------------------------------------------------------------------
+# gather_items
+# ---------------------------------------------------------------------------
+
+class TestGatherItems(unittest.TestCase):
+    def test_player_only_no_filter(self):
+        p = _FakePlayer(items=[_weapon('SWORD', 1), _thing('LANTERN', 2)])
+        got = gather_items(p)
+        self.assertEqual([c.name for c in got], ['SWORD', 'LANTERN'])
+        self.assertTrue(all(c.owner is None for c in got))
+
+    def test_category_filter(self):
+        p = _FakePlayer(items=[_weapon('SWORD', 1), _thing('LANTERN', 2)])
+        got = gather_items(p, category=ItemCategory.WEAPON)
+        self.assertEqual([c.name for c in got], ['SWORD'])
+
+    def test_predicate_anded_with_category(self):
+        p = _FakePlayer(items=[_weapon('LONG SWORD', 1), _weapon('SHORT BOW', 2)])
+        got = gather_items(p, category=ItemCategory.WEAPON,
+                           predicate=lambda it: 'BOW' in it.name)
+        self.assertEqual([c.name for c in got], ['SHORT BOW'])
+
+    def test_readied_flag_set_for_player(self):
+        w = _weapon('SWORD', 1)
+        p = _FakePlayer(items=[w], readied_weapon=w)
+        got = gather_items(p, category=ItemCategory.WEAPON)
+        self.assertTrue(got[0].readied)
+
+    def test_include_allies_appends_after_player_grouped_by_ally(self):
+        pw = _weapon('SWORD', 1)
+        aw1 = _weapon('AXE', 2)
+        aw2 = _weapon('MACE', 3)
+        alan = _FakeAlly('Alan', items=[_make_entry(aw1)], readied_weapon=aw1)
+        bo = _FakeAlly('Bo', items=[_make_entry(aw2)])
+        p = _FakePlayer(items=[pw], party=_FakeParty([alan, bo]))
+        got = gather_items(p, category=ItemCategory.WEAPON, include_allies=True,
+                           allies=[alan, bo])
+        self.assertEqual([c.name for c in got], ['SWORD', 'AXE', 'MACE'])
+        self.assertEqual([c.owner_name for c in got], ['You', 'Alan', 'Bo'])
+        # the ally's readied weapon carries the flag
+        self.assertTrue(got[1].readied)
+        self.assertFalse(got[2].readied)
+
+    def test_include_player_false(self):
+        aw = _weapon('AXE', 2)
+        alan = _FakeAlly('Alan', items=[_make_entry(aw)])
+        p = _FakePlayer(items=[_weapon('SWORD', 1)], party=_FakeParty([alan]))
+        got = gather_items(p, category=ItemCategory.WEAPON,
+                           include_player=False, include_allies=True,
+                           allies=[alan])
+        self.assertEqual([c.name for c in got], ['AXE'])
+
+
+class _Entry:
+    def __init__(self, item):
+        self.item = item
+
+
+def _make_entry(item):
+    return _Entry(item)
+
+
+# ---------------------------------------------------------------------------
+# resolve_or_prompt
+# ---------------------------------------------------------------------------
+
+class TestResolveOrPrompt(unittest.IsolatedAsyncioTestCase):
+    def _choices(self):
+        return [
+            ItemChoice(item=_weapon('LONG SWORD', 1)),
+            ItemChoice(item=_weapon('SHORT SWORD', 2)),
+            ItemChoice(item=_weapon('BATTLE AXE', 3)),
+        ]
+
+    async def test_name_unique_match_returns_without_prompt(self):
+        ctx = _FakeCtx(_FakePlayer())
+        got = await resolve_or_prompt(
+            ctx, self._choices(), args=['axe'], prompt_text='Ready which',
+            label_fn=lambda c: c.name)
+        self.assertEqual(got.name, 'BATTLE AXE')
+        self.assertEqual(ctx.sent(), '')  # nothing printed
+
+    async def test_name_no_match_sends_custom_message(self):
+        ctx = _FakeCtx(_FakePlayer())
+        got = await resolve_or_prompt(
+            ctx, self._choices(), args=['mace'], prompt_text='Ready which',
+            label_fn=lambda c: c.name,
+            no_match_msg=lambda q: f'No weapon or ally matching "{q}".')
+        self.assertIsNone(got)
+        self.assertIn('No weapon or ally matching "mace".', ctx.sent())
+
+    async def test_name_ambiguous_prompts_and_picks(self):
+        ctx = _FakeCtx(_FakePlayer(), answers=['2'])
+        got = await resolve_or_prompt(
+            ctx, self._choices(), args=['sword'], prompt_text='Ready which',
+            label_fn=lambda c: c.name, ambiguous_header='Which weapon?')
+        self.assertEqual(got.name, 'SHORT SWORD')
+        self.assertIn('Which weapon?', ctx.sent())
+        self.assertIn('1. LONG SWORD', ctx.sent())
+        self.assertIn('2. SHORT SWORD', ctx.sent())
+
+    async def test_full_list_numbered_pick(self):
+        ctx = _FakeCtx(_FakePlayer(), answers=['3'])
+        got = await resolve_or_prompt(
+            ctx, self._choices(), args=[], prompt_text='Ready which weapon',
+            label_fn=lambda c: c.name, list_header='Weapons:')
+        self.assertEqual(got.name, 'BATTLE AXE')
+        self.assertIn('Weapons:', ctx.sent())
+
+    async def test_blank_reply_is_a_silent_cancel(self):
+        ctx = _FakeCtx(_FakePlayer(), answers=[''])
+        got = await resolve_or_prompt(
+            ctx, self._choices(), args=[], prompt_text='x',
+            label_fn=lambda c: c.name)
+        self.assertIsNone(got)
+
+    async def test_out_of_range_reply_sends_invalid(self):
+        ctx = _FakeCtx(_FakePlayer(), answers=['9'])
+        got = await resolve_or_prompt(
+            ctx, self._choices(), args=[], prompt_text='x',
+            label_fn=lambda c: c.name)
+        self.assertIsNone(got)
+        self.assertIn('Invalid selection.', ctx.sent())
+
+    async def test_non_numeric_reply_sends_invalid(self):
+        ctx = _FakeCtx(_FakePlayer(), answers=['huh'])
+        got = await resolve_or_prompt(
+            ctx, self._choices(), args=[], prompt_text='x',
+            label_fn=lambda c: c.name)
+        self.assertIsNone(got)
+        self.assertIn('Invalid selection.', ctx.sent())
+
+    async def test_empty_choices_returns_none(self):
+        ctx = _FakeCtx(_FakePlayer())
+        got = await resolve_or_prompt(
+            ctx, [], args=[], prompt_text='x', label_fn=lambda c: c.name)
+        self.assertIsNone(got)
+
+    async def test_auto_select_single_skips_menu(self):
+        ctx = _FakeCtx(_FakePlayer())
+        one = [ItemChoice(item=_weapon('ONLY BLADE', 1))]
+        got = await resolve_or_prompt(
+            ctx, one, args=[], prompt_text='x', label_fn=lambda c: c.name,
+            auto_select_single=True)
+        self.assertEqual(got.name, 'ONLY BLADE')
+        self.assertEqual(ctx.sent(), '')
+
+    async def test_auto_select_single_off_by_default_shows_menu(self):
+        ctx = _FakeCtx(_FakePlayer(), answers=['1'])
+        one = [ItemChoice(item=_weapon('ONLY BLADE', 1))]
+        got = await resolve_or_prompt(
+            ctx, one, args=[], prompt_text='x', label_fn=lambda c: c.name)
+        self.assertEqual(got.name, 'ONLY BLADE')
+        self.assertIn('1. ONLY BLADE', ctx.sent())
+
+    async def test_group_fn_sections_full_list_with_continuous_numbering(self):
+        ctx = _FakeCtx(_FakePlayer(), answers=['3'])
+        choices = [
+            ItemChoice(item=_weapon('SWORD', 1)),
+            ItemChoice(item=_weapon('AXE', 2), owner=_FakeAlly('Alan')),
+            ItemChoice(item=_weapon('MACE', 3), owner=_FakeAlly('Bo')),
+        ]
+        got = await resolve_or_prompt(
+            ctx, choices, args=[], prompt_text='Ready which weapon',
+            label_fn=lambda c: (f'{c.owner_name}: {c.name}' if c.is_ally else c.name),
+            group_fn=lambda c: ("Your allies' weapons:" if c.is_ally
+                                else 'Weapons you carry:'))
+        out = ctx.sent()
+        self.assertIn('Weapons you carry:', out)
+        self.assertIn("Your allies' weapons:", out)
+        self.assertIn('1. SWORD', out)
+        self.assertIn('2. Alan: AXE', out)
+        self.assertIn('3. Bo: MACE', out)
+        self.assertEqual(got.name, 'MACE')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/server/tests/test_inventory_select.py
+++ b/server/tests/test_inventory_select.py
@@ -121,6 +121,14 @@ class TestGatherItems(unittest.TestCase):
                            predicate=lambda it: 'BOW' in it.name)
         self.assertEqual([c.name for c in got], ['SHORT BOW'])
 
+    def test_predicate_alone_no_category(self):
+        # How USE selects: no category, a "not a weapon" predicate.
+        p = _FakePlayer(items=[_weapon('SWORD', 1), _thing('LANTERN', 2),
+                               _thing('COMPASS', 3)])
+        not_weapon = lambda it: str(it.category) != str(ItemCategory.WEAPON)
+        got = gather_items(p, predicate=not_weapon)
+        self.assertEqual([c.name for c in got], ['LANTERN', 'COMPASS'])
+
     def test_readied_flag_set_for_player(self):
         w = _weapon('SWORD', 1)
         p = _FakePlayer(items=[w], readied_weapon=w)
@@ -230,6 +238,17 @@ class TestResolveOrPrompt(unittest.IsolatedAsyncioTestCase):
             label_fn=lambda c: c.name)
         self.assertIsNone(got)
         self.assertIn('Invalid selection.', ctx.sent())
+
+    async def test_invalid_msg_override(self):
+        # USE keeps SPUR's "You don't have that item." for a bad pick.
+        ctx = _FakeCtx(_FakePlayer(), answers=['9'])
+        got = await resolve_or_prompt(
+            ctx, self._choices(), args=[], prompt_text='Use which item',
+            label_fn=lambda c: c.name,
+            invalid_msg="You don't have that item.")
+        self.assertIsNone(got)
+        self.assertIn("You don't have that item.", ctx.sent())
+        self.assertNotIn('Invalid selection.', ctx.sent())
 
     async def test_empty_choices_returns_none(self):
         ctx = _FakeCtx(_FakePlayer())


### PR DESCRIPTION
## What

New `server/inventory_select.py` — a shared "pick an item of type X" helper — and READY, UNREADY, USE and DROP all moved onto it.

Each of those four commands used to hand-roll the same two steps: build a numbered list of the items a player can act on (sometimes just their pack, sometimes their pack plus every party ally's), then resolve a typed name **or** run a numbered menu down to exactly one item — with its own copy of the empty / one-match / ambiguous / cancel / bad-input handling.

## The helper

- **`gather_items(player, *, category=, predicate=, include_player=, include_allies=, allies=)` → `list[ItemChoice]`**
  Numbered list; player's pack first, then each ally's, grouped by ally. Each `ItemChoice` carries the item, its `InventoryEntry`, its `owner` (`None` = the player, else the `Ally`), and whether it's that owner's readied weapon. `category` and `predicate` are both filters, combined as logical AND.
- **`resolve_or_prompt(ctx, choices, *, args, prompt_text, label_fn, match_fn=, group_fn=, list_header=, ambiguous_header=, no_match_msg=, invalid_msg=, auto_select_single=)` → `ItemChoice | None`**
  Name match or numbered menu → one choice, or `None` for every dead end (nothing to pick, no match, cancel, bad input). `group_fn` splits the full list into labelled sections with continuous numbering.
- `_party_allies()` / `owner_has_readied()` / `same_item()` moved here so all callers share one copy. `same_item()` keeps the id-number-per-category rule (weapons/items/rations each number from 1).

## Per-command

| command | gather | quirk kept via |
|---|---|---|
| READY | `category=WEAPON, include_allies=True` | `group_fn`, `match_fn` (also matches ally names) |
| UNREADY | the party's readied weapons | `auto_select_single=True` (lone weapon repacks with no menu) |
| USE | `predicate`: not a weapon | `invalid_msg="You don't have that item."` |
| DROP | everything — no filter | `label_fn`: `" x{n}"` stack suffix |

All domain logic downstream of the pick is untouched (STR gate, STORM/Excalibur/Death-Amulet handling, ammo warnings, water-room drop, tool-kit/communicator/vial dispatch).

### Behaviour changes (minor)

- **USE**: naming a fragment that matches several items now opens a "Which one?" sub-prompt instead of silently using the first match.
- **READY**: a name narrowed to several of your *own* weapons shows them in the same `name / class / battle-exp` columns as the bare list, instead of bare names.
- **DROP**: cancel hint `(1-N, or RETURN to cancel)` → `(1-N, RETURN to cancel)`; a non-numeric / out-of-range pick on the full list now says `Invalid selection.` rather than `You are not carrying item N.`

## Tests

- New `server/tests/test_inventory_select.py` — 24 cases: `gather_items` filtering / ally-walk / readied flag, and every `resolve_or_prompt` branch (name match, ambiguous menu, grouped sections, cancels, bad input, `auto_select_single`, custom messages).
- Existing `test_ready.py` / `test_unready.py` / `test_use_*.py` / `test_drop.py` pass unchanged.
- Full suite: `4397 passed`, 2 skipped. The 2 failures on this branch (`test_get_unconscious`, `test_give_no_target_asks_whom`) are pre-existing on `master` and unrelated.

## Net

`ready.py` −140, `drop.py` −53, `use.py` −20; `+313` for the shared module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UgzkSgmKtqBeHM9pc771KH
