### PR TITLE
give, take: onto inventory_select; TAKE can reroute an item ally-to-ally

### DIFF
--- a/server/FUNCTIONS.md
+++ b/server/FUNCTIONS.md
@@ -738,10 +738,11 @@ say/shout/whisper/page — no `Command` subclass of its own, despite the name.
 ---
 
 ## inventory_select.py
-Shared "pick an item of type X" plumbing for READY, UNREADY, USE and DROP:
-gather a numbered list from the player's pack (plus each party ally's pack, for
-READY/UNREADY), then resolve a typed name or run the numbered prompt down to one
-choice.
+Shared "pick an item of type X" plumbing for READY, UNREADY, USE, DROP, GIVE and
+TAKE: gather a numbered list from the player's pack and/or each party ally's
+pack, then resolve a typed name or run the numbered prompt down to one choice.
+`resolve_or_prompt()` also works on any labelled list (Ally objects, `(label,
+payload)` tuples) -- GIVE's "which ally?" and TAKE's "give to whom?" reuse it.
 
 | Symbol / Function                       | Notes                                                                                         |
 |-----------------------------------------|----------------------------------------------------------------------------------------------|

--- a/server/MECHANICS.md
+++ b/server/MECHANICS.md
@@ -158,7 +158,7 @@ gap: level 5's header declares 400 rooms but `level_5.json` only has 1–373.
 - **Wizard's glow** — item `zu$[7]` values 2/3 reduce incoming damage by 2 (`SPUR.COMBAT.S:266` master / `:306` skip, unchanged)
 - **Lazer shield** — energized shield variant; blocks laser fire at half damage (`SPUR.USE.S:86` master, includes an "ALREADY ENERGIZED" duplicate-use guard; skip's `lazer.sh` moves to `:147–151` and drops that duplicate-energize message — silently no-ops instead — core 50% reduction unchanged)
 - **Power armor** — specific item; halves blast damage (`SPUR.USE.S:124` master / `:206` skip, unchanged verbatim)
-- ✅ **Crystal Pendant** (item #82) — resolved once per encounter, not per round (`SPUR.MISC4.S` `mon.set`/`stone`, called when the monster is first set up): if the player carries it and the monster can `petrify`, 90% chance to permanently disable that monster's turn-to-stone for the rest of the fight ("The CRYSTAL PENDANT flashes, preventing TURN TO STONE by `<monster>`!"), 10% chance the monster "happens to see" it and dons anti-pendant glasses that one time (petrification remains possible for the rest of the fight either way) (`combat/engine.py` `CombatSession._check_crystal_pendant()`)
+- ✅ **Crystal Pendant** (item #82) — resolved once per encounter, not per round (`SPUR.MISC4.S` `mon.set`/`stone`, called when the monster is first set up): if the player has it *worn* (`PlayerFlags.PENDANT_WORN`, toggled via `WEAR` — see the Weapons & Readying section; SPUR.MISC4.S:194's own "glasses" flavor already calls this "wearing the CRYSTAL PENDANT", so a bare inventory check isn't enough) and the monster can `petrify`, 90% chance to permanently disable that monster's turn-to-stone for the rest of the fight ("The CRYSTAL PENDANT flashes, preventing TURN TO STONE by `<monster>`!"), 10% chance the monster "happens to see" it and dons anti-pendant glasses that one time (petrification remains possible for the rest of the fight either way) (`combat/engine.py` `CombatSession._check_crystal_pendant()`)
 
 #### Monster abilities
 - **Monster spellcasting** — monsters with `+` flag in `wy$` can cast spells when low HP (`SPUR.COMBAT.S` `lnk.msc4`)
@@ -237,7 +237,58 @@ gap: level 5's header declares 400 rooms but `level_5.json` only has 1–373.
   `SPUR.LOGON.S:77`), not the Assassin class at all. So the description as written only
   matches skip's code; master's line 137 penalizes Orcs with bows, not Assassins. Worth
   confirming which branch's rule the port is meant to follow before treating this as settled.
-- ✅ **UNREADY command** — clears readied weapon; "No weapon readied!" if nothing's equipped (`SPUR.MAIN.S:84-85`, `commands/unready.py`)
+- ✅ **UNREADY command** — bare `unready` (alias `unwield`) repacks the player's
+  own readied weapon ("You repack the X."), or "No weapon readied!" if nothing is
+  (`SPUR.MAIN.S:84-85` master / `:90-91` skip, unchanged). No confirm, no STORM
+  special-casing (STORM only resists being *replaced*, not repacked). **TADA
+  extension**: since allies no longer auto-ready a GIVEn weapon, the player drives
+  both ends — when any party ally also has a weapon readied, bare `unready` shows a
+  numbered menu of *every* readied weapon (yours first, then each ally's) instead of
+  the direct repack; `unready <ally>` targets that ally's weapon by name
+  (`commands/unready.py`).
+- ✅ **READY / UNREADY an ally's weapon** — READY and UNREADY both operate on the
+  player's pack *plus* every party ally's pack (`inventory_select.gather_items(
+  include_allies=True)`); readying a weapon that's already an ally's readied weapon
+  toggles it back off. GIVE no longer auto-readies — the player decides who wields
+  what and when (alpha-tester feedback). Ally ammo counters
+  (`ammo_rounds`/`ammo_max`/`ammo_damage`) reset on every ally ready/unready
+  (`commands/ready.py` `_toggle_ally_weapon()`, `commands/unready.py`).
+- ✅ **Ally projectile-weapon no-ammo warning** — when an ally is directed to ready a
+  projectile/energy weapon (weapon class `projectile`/`energy`, STORM excluded), the
+  freshly-readied weapon always starts at zero rounds and an ally has no USE command
+  to load its own — so READY warns immediately ("`<ally>` has no ammunition loaded
+  for the X.") rather than letting it surface mid-fight as an auto-miss
+  (`combat/resolution.py` `ally_attacks()` misses on `rounds < 1`). Non-expert
+  players also get a follow-up hint naming a matching ammo item in the pack to GIVE
+  the ally, or "will need ammunition before it fires" if none is carried
+  (`commands/ready.py` `_weapon_needs_ammo()`/`_matching_ammo_in_inventory()`). TADA
+  addition — SPUR allies never carried their own unloaded ranged weapons.
+- ✅ **`inventory_select.py` — shared item picker** — READY/UNREADY, USE, DROP, GIVE,
+  and TAKE all resolve "pick an item of type X" through one helper:
+  `gather_items()` builds the numbered list (own pack, optionally `+` every party
+  ally's pack), `resolve_or_prompt()` turns a typed name or an interactive numbered
+  prompt into exactly one choice with uniform empty/one-match/ambiguous/cancel/
+  bad-input handling. A `predicate=` callable filters to the acting command's item
+  kind. Commands keep all their own domain logic (STR gates, STORM tantrums, water
+  rooms, …) and stop re-implementing the list and menu.
+- ✅ **WEAR / UNWEAR** (`commands/wear.py`, `commands/unwear.py`) — the armor-slot
+  counterpart to READY/UNREADY, added alongside the 2026-08-08 per-item durability
+  redesign (equipping is now non-consuming, so there has to be a way to take a piece
+  back off). `WEAR` (ports `SPUR.SUB.S`'s `wear` label) equips an `objects.json`
+  armor item: `player.active_armor_id` is set and `player.armor` mirrors that item's
+  own `.condition` (0–100, degrades from combat hits), capped by class/race per
+  `SPUR.SUB.S:33-35` — Pixie/Hobbit/Gnome 50%, Assassin/Elf 60%, everyone else 100%.
+  Battle armor (#113) = flat 125%, power armor (#115) = flat 150% (SPUR flavor
+  exceptions, keep their rating regardless of condition). Swapping in a different
+  piece leaves the old one in the pack at its last condition. `WEAR` also toggles two
+  items moved here from USE at Ryan's call ("wear" reads better than "use"): the ring
+  of invisibility (#67 → `PlayerFlags.RING_WORN`, see survival tick / Ringwraith) and
+  the crystal pendant (#82 → `PlayerFlags.PENDANT_WORN`, the petrify-block flag the
+  Combat section's Crystal Pendant bullet now requires). `UNWEAR` (new in TADA,
+  sibling of `unready`) takes armor and/or shield back off — the item is untouched,
+  just no longer `active_armor_id`/`active_shield_id`; a bare `unwear` disambiguates
+  when both slots are filled. Not ported: the separate `SPUR.COMBAT.S` `gauntlet`
+  hit-absorption mechanic (no engine hook yet).
 
 ### Not Implemented
 - ✅ **Battle experience accumulation** — `vp`/`weapon_experience` for the currently-readied weapon goes up by 1 only on landing the killing blow (not per swing -- `vp=vp+1` is only ever reached at SPUR.MISC.S:384 `p.a3`, confirmed by grepping every .S file); VETERAN at 40 kills, ELITE at 99 (`SPUR.MISC.S:384`, `player.py` `gain_weapon_experience()`, `engine.py` `_monster_dies()`). Corrected this session -- an earlier version incremented it after every swing (hit or miss) and even credited every other attacker in the room for the swinger's weapon; see `tests/test_battle_experience.py`.
@@ -260,13 +311,77 @@ gap: level 5's header declares 400 rooms but `level_5.json` only has 1–373.
 - ✅ **Grenade** — hurl at room monster; damage = 1d10 + 5 + (xp_level × 2); no monster: "harmlessly"; kills monster if HP reaches 0; item consumed (`SPUR.USE.S:91`, `commands/use.py`)
 - **Potion** — restore HP or stats (`SPUR.USE.S`)
 - **Rocket** — single-use ranged explosive; several variants (TOW, LAW, Redeye, plasma, nuclear) (`SPUR.USE.S:97–130`)
-- **Scrolls / spellcasting** (`SPUR.MISC3.S`)
+- ✅ **Scrolls / spellcasting** (`SPUR.MISC3.S`) — `CAST` is implemented; see the
+  **Spellcasting** section below.
 - **Spacesuit assembly** — combine parts 134 + 135 with tool into item 122 (`SPUR.USE.S:58–72`)
 - **Communicator repair** — USE tool on item 141 produces item 66 (`SPUR.USE.S:70`)
 - **Ruby slippers** — teleport-home to level 1 room 1 (`SPUR.USE.S:25,142–145`)
 - **Palintar** — links to misc6 (`SPUR.USE.S:20`)
 - **Crystal vial** — location-specific effect (`SPUR.USE.S:23–24`)
 - ✅ **Ammo consumption in combat** — projectile/energy weapons check `player.ammo_rounds` before swinging; "NO AMMO READY" blocks attack; `ammo_damage` added to hit damage; one round decremented per swing (`SPUR.COMBAT.S:44,84,99,144`)
+
+---
+
+## Spellcasting
+
+Ported from `SPUR.MISC3.S`'s `cast`/`cst.outc`/`cast.spl` labels (verified against
+source, both branches). Related shop/inventory plumbing — buying spells from the
+Wizard, the TADA Spell Book, `spellbook.ensure_spellbook()`/`spell_entries()` — is
+covered under **Merchant Shoppe → Wizard** and **Spell Book** above; this section is
+the CAST mechanic itself.
+
+### Implemented — `CAST` (`commands/cast.py`)
+- ✅ **One-shot spells** — a spell is removed from wherever `spellbook.spell_entries()`
+  found it (Spell Book, or the main inventory for non-Adepts / legacy saves) *before*
+  the outcome roll runs, so a fizzle or backfire still costs it — matching SPUR
+  clearing the known-spell entry (`xs$`) before it even reads the spell record.
+- ✅ **Outcome roll** (`cst.outc`) — `b = max(3, 20 − INT)`, `+2` if the caster's race
+  is Ogre (SPUR `pr=2` — a race, not a class); `a = random(b×100)/100 + 1` compared
+  against the spell's 1–9 success stat (`Spell.cast_chance` is that value ×10 for
+  display, so the threshold is `cast_chance/10`). `a < threshold` → success; else a
+  second `random(10)`: `<5` → backfire, otherwise → fizzle. A fizzle never reaches an
+  effect handler at all (SPUR `if (not b) goto spl.fail`); only success and backfire
+  do.
+- ✅ **Bonuses** (`cast.spl`, success only) — Druids `+2` ("DRUID POWER!") on every
+  non-monster-damage spell; a Wizard with a staff readied (`commands/get.py`'s
+  `_STAFF_IDS`) gets `+1` on stat spells ("The staff trembles..") or `+4` on
+  monster-damage, plus (Wizard only) `+5` XP and a damage bump on monster-damage.
+- ✅ **Effect scope built** (Ryan's choice) — stat spells S/W/D/C/E/I (with per-stat
+  success/backfire flavor and race-aware caps in `_stat_cap()`), heal (P),
+  monster-damage (M — requires an active `CombatSession`, a deliberate simplification
+  vs. SPUR's "any time a monster is in the room"), gold-to-bank transfer (T),
+  CONJURE FOOD / CONJURE DRINK (F/K), RESURRECT (V), and ENCHANT ARMOR / ENCHANT
+  SHIELD (Y/Z — adapted from `origin/skip`'s otherwise-unreachable `enchant` aura
+  sub-effect; TADA additions, not SPUR-sourced).
+- ⏸️ **Deferred, refused without consuming the spell** — level up/down (U/L),
+  teleport-to-shoppe (R), and the non-BOOTS Aura sub-effects (DISPEL POISON / APPLE A
+  DAY / DRUID HEALTH / WIZARD'S GLOW — each has a real hook already, just not wired
+  into CAST this pass).
+- ⏸️ **Deferred but flavor-stubbed** (rolls normally, spell *is* consumed, success
+  text with no mechanical payload) — SUMMON SPUR (G, no NPC to summon) and Aura's
+  BOOTS OF SPEED (no session-countdown clock to extend).
+
+### Implemented — `CHARM` (`spells/charm.py`)
+- ✅ **CHARM POTION** (rations.json #68) — drinking it targets the monster in the
+  current room and sets `player.pending_charm` (SPUR `zq=2`), unless the monster is
+  mechanical or `tough` (`SPUR.SUB.S:146-147`). While charmed, room descriptions show
+  `<monster> is charmed: "Gosh, er... hi, <player>!"` (SPUR prints only the quoted
+  half; the `<monster> is charmed:` prefix is a TADA clarity addition). Trying to
+  leave the room prompts a Y/N join offer: yes → the monster becomes an
+  `AllyStatus.SERVANT` ally; no → an honor penalty and the charm wears off.
+  (`SPUR.SUB.S`/`SPUR.MISC5.S` `charm`, `SPUR.MISC4.S:246`, `SPUR.MAIN.S:192`, both
+  branches identical.)
+- ✅ **Spontaneous potion-less charm** — `encounters/monster.py` also sets
+  `player.pending_charm` from `SPUR.MISC4.S rd.mons`'s own charm-on-encounter roll
+  (`d.charm`, gated on the monster's `charmable` AC flag); both routes converge on the
+  same join-offer flow, matching `SPUR.MAIN.S:192`.
+- ✅ **Shared-map safety** — a charmed-and-recruited monster is tracked per-player via
+  `player.charmed_monsters` (mirrors `player.dead_monsters`) rather than clearing
+  `room.monster`, so other players still see the monster normally. Bystander room
+  broadcasts on all three outcomes (charm / accept / decline) are a TADA addition.
+- **Note**: CHARM is not yet a `CAST`-able spell — potion and spontaneous roll only.
+  `charm.py`'s docstring still says "no spell-casting system at all yet", which is now
+  stale (CAST exists; it just has no CHARM effect handler).
 
 ---
 
@@ -497,11 +612,22 @@ gap: level 5's header declares 400 rooms but `level_5.json` only has 1–373.
      or `both` — checks `player.inventory` for `config.victory_item_number`.
   3. Silver in hand, only when `victory_type` is `gold` or `both` —
      checks against `config.victory_gold_amount`. SPUR's actual gate here
-     was a "riches of Tut" flag (`zu$` position 9), never wired up in
-     this port (`player.tuts_treasure_looted` / `flags.py`'s
-     `TutTreasure` dataclass are both dead code) — `config.py` deliberately
+     was a "riches of Tut" flag (`zu$` position 9); `config.py` deliberately
      generalized this into a plain silver threshold instead, predating
-     `victory.py`.
+     `victory.py`, so `victory.py` does **not** consult the Tut flag.
+     (`flags.py`'s `TutTreasure` dataclass and `player.tuts_treasure` are
+     *not* dead code, contrary to an earlier note here — they now back the
+     standalone quest #16 "Tut's Treasure" mechanic; see below.)
+- ✅ **Quest #16 — Tut's Treasure** (`quests/tuts_treasure.py`, ported from
+  `SPUR.MISC.S`'s `pandora`/`get.itm`/`treasure` and `SPUR.MISC3.S`'s
+  `exam3`/`treasure`) — item #86 "Tut's Treasure" in level 2 room 158
+  "Secret Chamber", guarded by monster #102 KING TUT in the adjacent room
+  157. `EXAMINE` it first disarms a trap and gives +2 INT (only under 25);
+  `GET` it afterward awards a ~1000× gold bonus; `GET` without examining
+  first triggers the Mummy's curse (the standard cursed-item XP/CON/INT/HP
+  penalties). State on `player.tuts_treasure` (`flags.py`'s `TutTreasure`,
+  mirroring SPUR's `zu$[9]`), round-tripped through save/load and surfaced
+  on the STAT screen. Wired into `commands/examine.py` and `commands/get.py`.
 - ✅ **On success** (`declare_victory()`): records the win
   (`winners.py`'s `record_win()` → `run/server/winners.json`), appends a
   `battle.log` entry, and posts a permanent news item ("A Winner!") —
@@ -614,7 +740,21 @@ No SPUR-source mechanic exists for wager/stakes (gold only changes hands via win
 - **Annex** — visitor area (`SPUR.ANNEX.S`) — see **Annex** section below
 - **Shop** — buy/sell items, ammo, shields (`SPUR.SHOP.S`) — see **Merchant Shoppe** section below
 - **Bulletin board / news log** (`SPUR.MISC2.S`) — see expanded design in **News & Mail** and **Threaded Message Boards** sections below
-- **Pray / Rest** — recover HP or stats out of combat (`SPUR.MISC2.S`)
+- ✅ **PRAY** (`commands/pray.py`, `SPUR.MISC2.S`'s `pray`) — beg the Spirit of the
+  Dungeons for a top-up when genuinely low on HP, Strength, or Energy. A `random(10)−3`
+  roll (−3..6) adjusted by honor (−1 under 800, −1 more under 400; +1 over 1200, +2
+  more over 1600 — SPUR's `xy>1600` is a transcription typo for `vk>1600`, corrected)
+  and class (Druid +2, Paladin +1). If the roll still beats HP, STR *and* EGY (nothing
+  actually critically low) the prayer is declined with a random SPUR flavor line
+  (harsher below 700 honor). Otherwise, once per session (twice for Druid/Paladin), a
+  second 6–10 roll per stat grants HP +10 and STR/EGY/CON +1 each where it beats the
+  current value (logged `PRAY` / `PIOUS PRAY`). Carrying real unused rations (any but
+  RED SERUM #44 / BLUE PILL #45 / POTION OF SKILL #65 / CHARM POTION #68) → "eat what
+  you're carrying first". Pray past the allowance and you get one warning
+  ("Buggest me oncest more and thou art toast!"); the next prayer is death by
+  lightning. TADA scaling: STR/EGY/CON grants are +1 (not SPUR's +10) since they're
+  1–18 attributes here, not vitality gauges; `prayed_count`/`prayer_punished` are
+  transient per-session (reset at login, like SPUR's `ys$`).
 - ✅ **READ command** — lists/reads book-type inventory items; item #69 "scrap of paper" is special-cased (see **Elevator Combination** section) (`commands/read.py`). **Not yet implemented**: the tips.txt claim that reading "increases your wisdom" — other books currently just print "there's nothing more to learn from it," per `read.py`'s own docstring (`SPUR.MISC3.S`; tips.txt: "READ books to increase your wisdom!")
 - ✅ **QUOTE command** — player sets a short quote (60 char max) shown to others who see them in a room; `$` substituted with the *reading* player's name; View/Write/Quit menu (`SPUR.MISC2.S:488-503` master / `:523-538` skip, byte-identical; also wired into character creation, `SPUR.LOGON.S:410,618-624`) (`commands/quote.py`, `commands/new_player.py`)
 - ✅ **LOOT command** — steal an item from another player in the room, once per session (twice for Outlaws); a fellow guild member of the target's guardian-blocks the theft; docks the thief's own Honor either way (`commands/loot.py`). Works against any player sharing the room regardless of consciousness -- no separate gating was needed once `PlayerFlags.UNCONSCIOUS` existed (see the Unconscious/duel-loss entry below), since the existing guardian-block already covers SPUR's "a guildmate protects you from being looted while unconscious" framing generically. The room-mate picker list also tags each name "watches you.." or "lies unconscious." (`SPUR.MISC3.S:539-559` `ply.locD`/`ply.loc3`), and looting an unconscious victim sends them a "while you were unconscious, you were robbed of your `<item>`!" mail notice from `mail.SYSTEM_SENDER` (`SPUR.MISC3.S:485-493`'s direct `dm$+"mail"` file write, routed through this port's real mail system instead). **Not yet implemented**: Civilians barred from the Shoppe after looting (tips.txt)
@@ -645,7 +785,12 @@ No SPUR-source mechanic exists for wager/stakes (gold only changes hands via win
 - ✅ **Wraith Master title** — players with `WRAITH_MASTER` flag get ", Wraith Master of Spur!" appended to their name at login (`commands/connect.py:251`)
 - ✅ **Login-time equipped-shield notice** — a currently-readied shield prints a sentence-cased "\<name\> is readied." line at login (`SPUR.LOGON.S`'s misc.data armor/shield reload loop — present in `origin/skip`'s fuller LOGON.S revision, absent from this repo's own SPUR-code copy); looked up by `player.active_shield_id` against `ctx.server.items`. No armor-side counterpart yet — `player.armor` is only a flat condition %, not tied to a specific item id (`commands/connect.py`'s `_login_equipment_lines()`).
 - **WHO command** — lists currently online players; replaces the SPUR "last adventurer" login display (stubbed in `commands/connect.py:247`)
-- **Guild follow** — player character automatically follows guild members to their location when logged off; toggle in settings (stubbed in `commands/connect.py:274`)
+- ✅ **Guild follow toggle** — `commands/follow.py` (`follow`, alias `fl`) ports
+  `SPUR.MISC5.S:240-245`'s `follow`: a guild-members-only (`vv<3` gate excludes
+  Civilian/Outlaw) toggle of `PlayerFlags.GUILD_FOLLOW_MODE`, also surfaced read-only
+  by `commands/stats.py` and settable via EditPlayer's Flags menu. **Still not done**:
+  the actual "follow guild members to their location when logged off" behaviour the
+  flag is meant to drive — only the toggle exists.
 - **DIG command** — dig for buried items or gold (`SPUR.MISC7.S:161 dig.a`
   master / `:173 skip`, unchanged — `SPUR.MISC7.S` exists on master too, it's
   not one of skip's five brand-new files, contrary to what the bare filename
@@ -679,7 +824,20 @@ No SPUR-source mechanic exists for wager/stakes (gold only changes hands via win
 - ✅ **Booby-trapped item pickup** — strange weapon (#70) / funny doll (#72): "BOOOMM!!" → INT−5, HP→5; Pandora's Box (#71): smoke → XP capped at 100, CON→5, INT−5, HP→5; Gold Rose (#41): DEX check, fail → −5 HP + poison; Fireplace (#81): "USE only" (can't be picked up); Obelisk (#139): too large (`SPUR.MISC.S get.itm`, `commands/get.py`)
 - ✅ **Fireplace USE** — room 103 "East Hall"; `use` or `use fireplace` while in room: restores Strength to 20 and heals +4 HP if both were low; room message shown to bystanders (`SPUR.USE.S:187`, `commands/use.py`)
 - ✅ **DROP command** — drop items into the room; water rooms (`@@` flag or keyword match on name/desc) show float/sink messages: metal weapons and heavy items sink and are lost, wooden weapons/food/books/darts/arrows float and remain retrievable; well rooms always lose the item; buoyancy inferred from category+name until a per-item flag exists (`SPUR.MISC.S`, `commands/drop.py`)
-- ✅ **GIVE / TAKE** — `give <item> to <ally/player/monster>` transfers item to ally's carried list or co-located player's inventory; giving to a monster yields humorous responses (food eaten, gold kept by greedy types, etc.); `take [<item>] from <ally>` retrieves items ally is holding (`SPUR.MISC.S:72-141` master / `:73-142` skip, byte-identical, `commands/give.py`, `commands/take.py`)
+- ✅ **GIVE / TAKE** — `give <item> to <ally/player/monster>` transfers item to ally's carried list or co-located player's inventory; giving to a monster yields humorous responses (food eaten, gold kept by greedy types, etc.); `take [<item>] from <ally>` retrieves items ally is holding (`SPUR.MISC.S:72-141` master / `:73-142` skip, byte-identical, `commands/give.py`, `commands/take.py`). Item selection on both is now the shared `inventory_select.py` picker (see the Weapons & Readying section). **TADA extensions**:
+  - GIVE no longer auto-readies a weapon given to an ally (alpha-tester feedback) —
+    the player readies it explicitly via READY, which now reaches into ally packs.
+  - `take` with no `from <ally>` (the *browse* forms — bare `take` or
+    `take from <ally>`), when more than one servant is in play, follows the item pick
+    with a "give to whom?" step: pick another ally and the item goes straight into
+    their pack, skipping the take-to-self-then-give-again shuffle (`take <item> from
+    <ally>` — the direct form — never offers this). The ally→ally hop is a plain
+    cargo move: no auto-ready / auto-wear / ammo-load, since those model the *player*
+    equipping an ally, not shuffling cargo (`take.py` `_reroute_between_allies()`).
+  - Mount carry capacity (no SPUR precedent): a MOUNT ally carries nothing until it
+    has `AllyFlags.SADDLEBAGS` (USE saddlebags), then holds up to
+    `_MOUNT_CAPACITY_WITH_SADDLEBAGS = 5` items; GIVE and the ally→ally reroute both
+    enforce it. Non-mount allies keep the unlimited `ally.items` list.
 - ✅ **ORDER command** — deploy up to 3 owned servants as Point Man / Flank Guard / Rear Guard; every owned servant must be placed somewhere (a slot can be left NONE if you own fewer than three), matching SPUR's "You didn't deploy ALL your servants!" retry loop; position persists across save/load (`bar.ally_data.Ally.position`, `party.py` to_json/from_json) (`SPUR.MISC2.S:36-70` master, `commands/order.py`). **Branch divergence**: skip (`:66,73-74` — offsets differ, same `order.a` label) adds an escape hatch master doesn't have — instead of an unconditional forced retry loop, skip prompts `"Dismiss the remainder? y/[N] :"` and, on "Y", lets the player proceed with unplaced servants dismissed outright (and logs the dismissal via `add.log`) rather than looping back to `order.a` every time.
 - ✅ **Tactical ambush** (`SPUR.MISC4.S:140-158` master `tactical`/`desert` / `:147-164` skip, core formula unchanged) — once per encounter, before the first exchange, an ambush falls on a random ORDER slot (Point 50% / Flank 20% / Rear 30%, `i$="1111122333"`). Whoever's deployed there shouts a warning and rolls to hold (an ELITE-flagged servant is always immune -- SPUR's literal "!" in the servant's name); failing that roll leaves the *player* caught off guard too (a bonus monster attack on the first swing, SPUR.COMBAT.S:31 "Surprise attack..") and a 1-in-10 chance the servant actually deserts (room-flavor text: ordinary/water/level-6+-vacuum). An empty slot puts the player alone at risk, rolled against Intelligence + character level plus a flat 10%. Skipped for a friendly encounter (same race/alignment affinity as the monster-quote greeting) and for any monster number already in `player.dead_monsters` (this port's equivalent of SPUR's xm$ rolling-kill-history gate) (`combat/engine.py` `CombatSession._check_tactical_ambush()`/`_ally_deserts()`, wired into `_run_loop()`). Skip-only additions are flavor, not mechanic: an extra `>`-flagged (incorporeal/undead ally?) case with its own SHOUTS text, and "TOO DISCIPLINED" replacing "TOO CLEVER" in the elite-immunity line — the 50/20/30 split, hold roll, and 1-in-10 desertion odds are otherwise identical.
 - **Ally payment** — allies require weekly payment (gold) to remain loyal; non-payment triggers desertion (`SPUR.MISC2.S`, confirmed real and unchanged on skip, not yet ported). Trigger gate: `SPUR.MISC.S:423` master / `:431` skip — flat 50% chance per non-water-room move (`gosub rnd.10z:if z>5 link dy$,"servant"`) to enter `ally` in `SPUR.MISC2.S:85-86` (master, same area skip); a further `random(100)>40` (60% of triggers) routes to the payment-demand path (`ally6`→`ally9`, master `SPUR.MISC2.S:~96-149`, skip `~174-216`). Demand amount `xu=gl/3` capped at 100 gold, identical both branches. Refusal consequence: honor (`vk`) penalty, ~30% honor-scaled chance of "looks grumpy," or full REVOLT/desertion+combat if honor drops low enough (`zs<41` after scaling) — formula unchanged both branches. Skip's only real addition: `>`-flagged (god/incorporeal) allies skip the payment demand entirely (`instr(">",zt$)` check folded into the `ally6` gate, skip `:178`).
@@ -687,7 +845,53 @@ No SPUR-source mechanic exists for wager/stakes (gold only changes hands via win
 - ✅ **Ally gold finding** — on each room move, any party ally has a 5% chance to find a gold sack (52–250 gp); fires at most once per day via `once_per_day` `'AYF'` tag; suppressed in water rooms (`SPUR.MISC6.S al.find:541-554` master / `:430-445` skip, `ally_events.py`, `simple_server._move()`). Gold formula (`z=(z*2)+50`, i.e. 52–250 gp) confirmed identical both branches; port's `ally_events/__init__.py` `_CHANCE = 0.05` is the port's own simplified standalone roll, not a literal SPUR percentage — real SPUR gating is compound (2%-per-move dispatcher entry at `SPUR.MAIN.S:239`, times a further ~15%-wide slice within it on master / ~17%-wide on skip), so "5%" doesn't trace to a specific SPUR source figure on either branch. **Branch divergence**: once-per-day tag semantics changed — master only marks the day's `*AYF` tag used on an *actual* gold find (an absent ally bails out before tagging); skip marks its `*AF` tag unconditionally, before even checking whether an ally is present, so on skip a move with no ally deployed still burns the day's allowance.
 - ✅ **Ally body building** — giving food/drink to an ally with strength < 11 raises their strength by 1; cursed rations poison the ally instead (strength −1, floor 1) (`SPUR.SUB.S hun.slv:370-384` master / `:500-518` skip, `commands/give.py _try_body_build()`). The port's own `+= 1` per feeding (vs. SPUR's `+4`) is a deliberate, already-documented port simplification, not a citation error. **Branch divergence**: skip replaces the hardcoded `<11` threshold with a variable (`if a2<b-4`, `b` not fully traced — likely a per-ally-type max-strength stat) and adds a new `ck.horse` gate (skip `SPUR.SUB.S:520-528`) that blocks the attempt with `"(<name> CAN NOT CONSUME THE <item>)"` unless the item is on a mount-appropriate allowlist (`objects.json` #4,14,16,20,23,24,25,39,41,50,61,63,77-82) — reads as skip's allies now including rideable/horse-type allies that can't eat ordinary rations, a case master's version doesn't handle.
 - **Ally desertion / death** — allies may die or leave if unpaid, injured, or mistreated; status reverts to FREE (`SPUR.MISC6.S dead.al:566-586` master / `:518-536` skip, formula unchanged: `a1<8`/`a2<8`/`a3<8` HP-below-8 check, honor/wisdom/intelligence penalties, battle-log write; not yet ported). **Branch divergence**: master only reaches `dead.al` through the same ~15%-of-2%-per-move random-event slice as galad/meteor/al.find/enforce; skip's `random` dispatcher (`SPUR.MISC6.S:141`) calls `dead.al` **unconditionally on every dispatcher fire**, in addition to then separately rolling galad/meteor/al.find/enforce/djinn — so ally starvation-death checks run far more often on skip. Skip also adds a `>`-flagged (incorporeal ally) branch at `dead.al2` (`:527-528`): "`<name>` looks annoyed, and flies away!" instead of "stumbles and falls," routed to a `god.lv` label instead of the normal "DIED IN `<room>`" battle-log line.
-- **Random events** — location-triggered events: little girl encounter, meteor strike, Enforcer arrival, Galadriel appearance (`SPUR.MISC6.S`, dispatcher at `no.test`/`random`, master `:152-159`: `z<15` galad, `z<30` meteor, `z<45` dead.al, `z<60` al.find, `z<80` enforce, else girl; not yet ported). **Branch divergence**: skip adds a sixth event, `djinn` (skip `SPUR.MISC6.S:554-567`, dispatcher `:143-149`: `z<15` galad, `z<32` meteor, `z<49` al.find, `z<66` enforce, `z<83` djinn, else girl), each individually gated by its own once-per-day tag (`*GA`/`*ME`/`*AF`/`*EN`/`*VN`) — master only gates `girl` (`*gi`) and `al.find` (`*AYF`) that way. `djinn` ("You think you see the Blue Djinn in the distance!") checks the player's honor/progress record (`spur.a1$` fields `g7`/`g8`) and, if low enough, silently deploys a hitman NPC named VINNEY against the player (writes a `thug` file, sets a thug-attack flag in `zu$`) — a bounty-hunter mechanic tied to the Bar's hired-hits feature (see **Bar** section) rather than a purely new random encounter.
+- ⚠️ **Random events** — location-triggered events off `SPUR.MAIN.S:239`'s 2%-per-move
+  world-event roll and its d100 sub-roll (`SPUR.MISC6.S` dispatcher at
+  `no.test`/`random`, master `:152-159`: `z<15` galad, `z<30` meteor, `z<45` dead.al,
+  `z<60` al.find, `z<80` enforce, else girl). **Partly ported, per-event, as separate
+  modules** — the real single-fire dispatcher isn't built yet, so each ported
+  sub-event currently flat-rolls its own composite share (e.g. Galadriel ≈ 0.3%/move)
+  and, unlike the original, more than one can fire on the same move:
+  - ✅ **Test of Galadriel** (`encounters/galadriel.py`, quest #8) — `*GAL` once-per-session tag.
+  - ✅ **Meteor / flying banshee** (`encounters/meteor.py`) — a dodge check, not a fight; `*ME` tag.
+  - ✅ **Little girl** (`encounters/little_girl.py`) — `*gi` tag.
+  - ✅ **Ally finds gold** — see the "Ally gold finding" bullet above (`ally_events/`).
+  - ✅ **Blue Djinn sighting** (`encounters/djinn_sighting.py`, skip-only `djinn`) — an
+    alternate trigger for the Bar's existing debt-collection ambush (`bar/thug_attack.py`).
+  - ❌ **The Enforcer** and ❌ **ally starvation-death** random-event path — documented, not built (`TODO.md`).
+- **Original "Random events" branch-divergence note (dispatcher shape)**: skip adds a sixth event, `djinn` (skip `SPUR.MISC6.S:554-567`, dispatcher `:143-149`: `z<15` galad, `z<32` meteor, `z<49` al.find, `z<66` enforce, `z<83` djinn, else girl), each individually gated by its own once-per-day tag (`*GA`/`*ME`/`*AF`/`*EN`/`*VN`) — master only gates `girl` (`*gi`) and `al.find` (`*AYF`) that way. `djinn` ("You think you see the Blue Djinn in the distance!") checks the player's honor/progress record (`spur.a1$` fields `g7`/`g8`) and, if low enough, silently deploys a hitman NPC named VINNEY against the player (writes a `thug` file, sets a thug-attack flag in `zu$`) — a bounty-hunter mechanic tied to the Bar's hired-hits feature (see **Bar** section) rather than a purely new random encounter.
+- ✅ **Desert / labyrinth / open-water direction loss** (`encounters/desert.py`,
+  `SPUR.MAIN.S`'s `rd.room2`/`coat`/`rd.room3`, master) — a room whose name contains
+  "DESERT" or "LABYRINTH", or carrying the `water`/`water_with_rocks` flag, hides its
+  exit list ("You lost your sense of direction.") unless the player has a compass
+  readied (USE), is a Ranger tracking, or — even in ordinary terrain — has
+  Wisdom+Intelligence < 10 (below that the gauntlet runs in *every* room). On map
+  level 6 ("outer space") neither compass nor tracking helps and the line becomes
+  "Star-filled blackness engulfs you." Ties to the "Special room traversal
+  requirements" and MAP-command entries.
+- ✅ **Mechanical-monster salvage** (`encounters/droid_salvage.py`,
+  `SPUR.MISC.S:406-415` `no.gold`/`no.salvg`, both branches) — killing a `:`-flagged
+  (mechanical) monster: 50% roll drops SALVAGE PARTS (item #146) into the room; and if
+  the killing weapon is an energy weapon (`wa=10`), a further roll leaves its power pak
+  "still energized" and recharges the readied weapon, else "destroyed".
+- ✅ **Guild turf-guard special cases** (`encounters/turf_guards.py`,
+  `SPUR.MISC4.S`/`SPUR.COMBAT.S`) — on top of `encounters/monster.py`'s friendly
+  turf-guard salute for monsters #65/66/67 (FIST/SWORD/CLAW guards): a 20% chance
+  (`SPUR.MISC4.S:69` `claw` label) the guard spawns as its guild's captain instead of
+  rank-and-file, and a surprised guard calls for backup.
+- ✅ **Gollum riddle guard** (`encounters/gollum.py`) — level 4 room 17 "Gollum's
+  Cave" holds both monster #71 and the ring (#67). Gollum now refuses to let the ring
+  be taken from under him (a real fight, like King Tut / the Dwarf guard their
+  hoards), and `SAY`/`ASK` a riddle in the cave opens a riddle exchange with him. The
+  riddle content is TADA-original — no SPUR "ask Gollum a riddle" source exists (the
+  Test of Galadriel is the one SPUR-sourced riddle mechanic, unrelated).
+- ✅ **Ringwraith (monster #70) special-case** (`encounters/ringwraith.py`,
+  `SPUR.MISC4.S`'s `wraith`, run before the turf-guard/mechanical checks at the top of
+  monster load) — sets the wraith's fixed ability string; if the player carries the
+  ring (`zu$` position 2) the monster is buffed (`ms += xp×7`) with an "(..oh, oh...
+  The ring..)" line; with honor ≤ 800 an alignment roll (Orc/Assassin +100) decides
+  whether "The Ringwraith recognizes one of his own kind!" and lets the player pass,
+  or it attacks.
 - ✅ **Turn to stone attack** — a `petrify`-flagged monster (e.g. Medusa) has a
   20% chance per attack to attempt petrification instead of a normal swing, 10% chance to
   succeed once attempted; either way this replaces the normal hit/damage roll entirely for
@@ -724,7 +928,24 @@ No SPUR-source mechanic exists for wager/stakes (gold only changes hands via win
   already matches this port's own sentence-case convention (see CLAUDE.md) here; skip
   regressed it, so master is the one to follow if porting the raw string verbatim mattered.
 - **STATS / STAT2** — two-level stat display; STAT2 shows extended information (`SPUR.MISC5.S`)
-- **FOLLOW ME command** — causes nearby players or allies to follow the player (`SPUR.MISC5.S`)
+- **FOLLOW ME command** — causes nearby players or allies to follow the player
+  (`SPUR.MISC5.S`, dispatched off its own token — a *different* mechanic from the
+  guild-follow toggle, which is ported; see "Guild follow toggle" above). The
+  companion-tracking "FOLLOW ME" itself is still not built.
+- ✅ **MAP** (`commands/map.py`) — the Ranger's wilderness sense, `SPUR.MISC5.S:13`'s
+  `#`-bound `ranger` ability (gated `xp>2` / character level 3+), given a real command
+  name here since this port's `#` is the admin TeleportCommand. SPUR just `show.file`d
+  a static pre-rendered `map.<level>` ASCII file plus "Room #<n>" and (level 1) a
+  Dwarf-location hint; this port instead computes a live "nearby rooms" listing by BFS
+  over each room's real resolved `.exits` links (no grid-stride metadata needed, works
+  on all loaded levels). Room *numbers* are shown only to Admin/DM — an ordinary
+  player gets the direction path and room name.
+- ✅ **ASK** (`commands/ask.py`) — like `SAY` but always uses the "asks" verb. Inside
+  Gollum's cave, while he's alive, a bare `ASK` (or `ASK RIDDLE` / `ASK GOLLUM`) opens
+  the riddle menu instead of broadcasting (see the Gollum riddle-guard bullet above).
+- ✅ **HISTORY + `^N` re-run** (`commands/history.py`) — lists the player's last
+  `Player.COMMAND_HISTORY_CAP` typed commands, most recent first; `^1` re-runs the most
+  recent, `^3` the third-most-recent, etc. Player convenience, no SPUR precedent.
 
 ### Future
 - **Chat channels** — named, persistent channels players can join/leave (e.g. `#general`, `#claw`,
@@ -748,7 +969,14 @@ No SPUR-source mechanic exists for wager/stakes (gold only changes hands via win
 
 ### Implemented
 - ✅ **General Store** — sells rations 1–10 (safe food/drink); duplicate check; silver deduction; pack-full guard (`SPUR.SHOP.S:293-325 general` master / `:317-348` skip, byte-identical logic besides string-padding cosmetics)
-- ✅ **Elevator** — travel between levels 1–5 (`shoppe/elevator.py`)
+- ✅ **Elevator** — travel between levels 1–5 (`shoppe/elevator.py`); level 6 is
+  reached via the ship transporter (`ship/transporter.py`, see the Elevator
+  Combination section). **Map data for levels 7 and 8 is now loaded** —
+  `simple_server.py` reads `level_<N>.json` for `N` in 1..8 (level 7 = SPUR's 7th
+  dungeon level; level 8 = "Forest of Canolbarth", a TADA addition built by
+  `tools/build_level_8_json.py`, non-grid breadth-first layout) — but neither the
+  elevator nor a traced in-game entrance reaches them yet; the hidden-exit
+  row-arithmetic method in the Flee/Travel section still only covers levels 1/2/5/6.
 - ✅ **Player List** — browse online/offline players by wildcard pattern
 - ✅ **Private Locker** (`shoppe/locker.py`) — personal item storage, reached
   by typing `LOCKER` at the Shoppe prompt (a free-text command, like
@@ -1277,6 +1505,11 @@ joke, no horse-strength gate, no per-class attack bonus table) — the master br
 - **Saddlebags** — bit 7 of `v2+189`; without saddlebags the horse carries no gold and no items;
   with saddlebags it can carry things (extra inventory).  Gold display routines explicitly check
   for this flag before showing horse gold.
+  - ✅ **Partly done (items only)**: a MOUNT ally with `AllyFlags.SADDLEBAGS` (via
+    `USE` saddlebags) can hold up to 5 items — `_MOUNT_CAPACITY_WITH_SADDLEBAGS` in
+    `commands/give.py`, enforced by GIVE and the TAKE ally→ally reroute (see the
+    GIVE/TAKE entry in Social/World). No SPUR precedent for a mount carry *limit*;
+    Ryan's number. Horse-carried *gold* is still unported.
 - ✅ **Saddle / Horse Armor** — bought at Jake's Stable, then `USE`d on a mount ally to
   equip it (`AllyFlags.SADDLED` / `AllyFlags.ARMORED` — the latter shared with the
   Allies' Guild's Armor training, same "$" sigil in SPUR either way); refuses without a
@@ -1295,7 +1528,8 @@ joke, no horse-strength gate, no per-class attack bonus table) — the master br
   instead of silently falling back to hack/slash/bash's.
 - Seed real mount Constitution/HP so "mount redirects a hit" can apply actual damage
   instead of being narrative-only.
-- Wire saddlebags into inventory as an extra carry slot on the horse.
+- Wire saddlebags into inventory as an extra carry slot on the horse — *item* carry
+  (5-slot cap) is done (see Saddlebags above); horse-carried gold is still open.
 - Add horseshoe service to the Blacksmith shoppe section.
 
 ---
@@ -1448,6 +1682,14 @@ above.
 
 #### World editing
 - **`editmonsters`** — in-game monster editor; admin only (`commands/editmonsters.py`).
+- ✅ **`list` / `find`** (`commands/list_locations.py`) — Admin/DM tool: scans every
+  room on every loaded level and reports where instances of a thing are placed.
+  `list #w[eapons]` / `#a[rmor]` / `#s[hield]` / `#i[tems]` / `#<objtype>` /
+  `#m[onsters]` / `#r[ations]`, plus an optional case-insensitive name substring
+  (`list #m goblin`). `list #w #tel` then prompts to pick a match and teleport there
+  (calls `TeleportCommand` with an explicit `(level, room)` pair). New in TADA — a
+  moderation/debug convenience, distinct from `editplayer`'s catalog browser (which
+  lists the *definitions*, not their placements).
 
 #### Development / ops
 - ✅ **`reload <module> [module...]`** — hot-reload command/support modules

--- a/server/commands/give.py
+++ b/server/commands/give.py
@@ -17,6 +17,7 @@ from commands.base_command import Command, CommandResult, Mode
 from commands.help import Help, HelpCategory
 from bar.allies import purchased_allies
 from flags import PlayerFlags
+from inventory_select import gather_items, resolve_or_prompt
 from network_context import GameContext
 
 _RING_ID = 67  # ring of invisibility (objects.json) -- see commands/wear.py
@@ -319,42 +320,23 @@ class GiveCommand(Command):
         else:
             item_words = arg_list
 
-        # Build the item pool from inventory
-        entries = list(inventory.entries()) if inventory else []
-        if not entries:
+        # Pick the item from your own pack -- name match or the numbered
+        # "Items you carry:" menu, via the shared picker (inventory_select).
+        choices = gather_items(player)
+        if not choices:
             await ctx.send('You have nothing to give.')
             return CommandResult.ok()
 
-        # Resolve item
-        if item_words:
-            pattern = ' '.join(item_words).lower()
-            matches = [e for e in entries
-                       if pattern in (getattr(e.item, 'name', '') or '').lower()]
-            if not matches:
-                await ctx.send(
-                    f'You are not carrying anything matching "{" ".join(item_words)}".')
-                return CommandResult.ok()
-            entry = matches[0]
-        else:
-            lines = ['', 'Items you carry:']
-            for i, e in enumerate(entries, 1):
-                lines.append(f'  {i:>2}. {getattr(e.item, "name", "?")}')
-            lines.append('')
-            await ctx.send(lines)
-            raw = await ctx.prompt(preamble_lines=f'(1-{len(entries)}, {ctx.player.return_key} to cancel)',
-                                   prompt_text="Give which item")
-            if not raw or not raw.strip():
-                return CommandResult.ok()
-            try:
-                idx = int(raw.strip()) - 1
-                if not (0 <= idx < len(entries)):
-                    raise ValueError
-            except ValueError:
-                await ctx.send('Invalid selection.')
-                return CommandResult.ok()
-            entry = entries[idx]
+        choice = await resolve_or_prompt(
+            ctx, choices, args=item_words, prompt_text='Give which item',
+            label_fn=lambda c: c.name,
+            list_header='Items you carry:',
+            no_match_msg=lambda q: f'You are not carrying anything matching "{q}".',
+        )
+        if choice is None:
+            return CommandResult.ok()
 
-        item  = entry.item
+        item  = choice.item
         iname = getattr(item, 'name', 'it')
 
         # Ring of invisibility (#67): can't give it away while worn
@@ -384,23 +366,16 @@ class GiveCommand(Command):
             if not allies:
                 await ctx.send('Give it to whom?  (Try: give <item> to <name>)')
                 return CommandResult.ok()
-            lines = ['', 'Give to which ally:']
-            for i, a in enumerate(allies, 1):
-                lines.append(f'  {i:>2}. {a.name}')
-            lines.append('')
-            await ctx.send(lines)
-            raw = await ctx.prompt(preamble_lines=f'(1-{len(allies)}, {ctx.player.return_key} to cancel)',
-                                   prompt_text="Give to whom")
-            if not raw or not raw.strip():
+            # Same shared picker as the item list -- Ally objects carry a
+            # .name, so resolve_or_prompt() lists them directly.
+            picked = await resolve_or_prompt(
+                ctx, allies, args=[], prompt_text='Give to whom',
+                label_fn=lambda a: a.name,
+                list_header='Give to whom?',
+            )
+            if picked is None:
                 return CommandResult.ok()
-            try:
-                idx = int(raw.strip()) - 1
-                if not (0 <= idx < len(allies)):
-                    raise ValueError
-            except ValueError:
-                await ctx.send('Invalid selection.')
-                return CommandResult.ok()
-            target = allies[idx].name.lower()
+            target = picked.name.lower()
         else:
             target = ' '.join(target_words).lower()
 

--- a/server/commands/take.py
+++ b/server/commands/take.py
@@ -7,6 +7,13 @@ Syntax:
   take                         list all items across all servants
   take from <ally>             list items that specific ally carries
   take <item> from <ally>      take a specific item directly
+
+TADA extension (JoyfulColor's request): when more than one servant is in
+play, bare TAKE follows the item pick with a "give to whom?" step -- pick
+another ally and the item goes straight into their pack, skipping the
+take-to-yourself-then-give-again shuffle. Picking "yourself" is the
+original behaviour. See _reroute_between_allies() for why the ally->ally
+hop is a plain cargo move (no auto-ready / auto-wear / ammo-load).
 """
 from __future__ import annotations
 
@@ -14,7 +21,50 @@ from commands.base_command import Command, CommandResult, Mode
 from commands.help import Help, HelpCategory
 from bar.ally_data import AllyStatus
 from bar.allies import purchased_allies
+from inventory_select import gather_items, resolve_or_prompt
 from network_context import GameContext
+
+
+async def _reroute_between_allies(ctx, player, src_ally, dest_ally, entry) -> CommandResult:
+    """Hand one unit of *entry*'s item from *src_ally*'s pack straight to
+    *dest_ally*'s, without it passing through the player's inventory.
+
+    Deliberately a plain relocation -- no auto-ready, auto-wear or
+    ammo-load. Those GIVE side-effects model the *player* equipping an
+    ally; shuffling cargo from one ally to another just moves the item.
+    READY / UNREADY already operate on either ally's pack
+    (inventory_select.gather_items(include_allies=True)), so the player
+    wields it from its new owner if they want to.
+    """
+    from bar.ally_data import add_ally_item
+    from commands.give import _mount_capacity
+
+    item  = entry.item
+    iname = getattr(item, 'name', 'it')
+
+    capacity = _mount_capacity(dest_ally)
+    if capacity is not None:
+        if capacity == 0:
+            await ctx.send(f'{dest_ally.name} has nowhere to carry it -- needs saddlebags first.')
+            return CommandResult.ok()
+        if len(dest_ally.items or []) >= capacity:
+            await ctx.send(f"{dest_ally.name}'s saddlebags are full.")
+            return CommandResult.ok()
+
+    # Take one unit off the source ally (decrement a stack, else drop the entry).
+    if getattr(entry, 'quantity', 1) > 1:
+        entry.quantity -= 1
+    elif entry in src_ally.items:
+        src_ally.items.remove(entry)
+    add_ally_item(dest_ally, item, quantity=1)
+    player.unsaved_changes = True
+
+    pself = getattr(player, 'name', 'Someone')
+    await ctx.send(f'{src_ally.name} hands the {iname} to {dest_ally.name}.')
+    await ctx.send_room(
+        f'{pself} has {src_ally.name} hand the {iname} to {dest_ally.name}.',
+        exclude_self=True)
+    return CommandResult.ok()
 
 
 class TakeCommand(Command):
@@ -39,6 +89,11 @@ class TakeCommand(Command):
             ('take sword from batman', 'Naming an item skips the listing and takes it '
                                         'directly, if Batman is actually carrying one '
                                         'matching that name.'),
+            ('take',                   "With two or more servants, bare TAKE asks who to "
+                                        "hand the item to after you pick it -- choose "
+                                        "another ally to move it straight across (no need "
+                                        "to TAKE it to yourself and GIVE it on), or "
+                                        "\"yourself\" to pocket it as before."),
         ],
     )
 
@@ -65,76 +120,78 @@ class TakeCommand(Command):
         else:
             item_words = arg_list
 
-        # Resolve ally subset
+        # Resolve which servant(s) to list from.
         if from_words:
             target = ' '.join(from_words).lower()
-            ally_matches = [a for a in active if target in a.name.lower()]
-            if not ally_matches:
+            selected = [a for a in active if target in a.name.lower()]
+            if not selected:
                 await ctx.send(
                     f'No servant named "{" ".join(from_words)}" in your party.')
                 return CommandResult.ok()
-            selected = ally_matches
         else:
             selected = active
 
-        # Collect (ally, entry) pool
-        pool: list[tuple] = []
-        for a in selected:
-            for e in (getattr(a, 'items', None) or []):
-                pool.append((a, e))
-
-        if not pool:
+        # The item pool = the selected servants' packs, numbered as one
+        # list (inventory_select.gather_items; each ItemChoice carries the
+        # ally who holds it as .owner).
+        choices = gather_items(player, include_player=False,
+                               include_allies=True, allies=selected)
+        if not choices:
             if from_words:
                 await ctx.send(f'{selected[0].name} is not carrying anything.')
             else:
                 await ctx.send('Your servants are not carrying anything.')
             return CommandResult.ok()
 
-        # Resolve item
-        if item_words:
-            pattern = ' '.join(item_words).lower()
-            matches = [(a, e) for a, e in pool
-                       if pattern in (getattr(e.item, 'name', '') or '').lower()]
-            if not matches:
-                pat_str = ' '.join(item_words)
-                await ctx.send(
-                    f'None of your servants are carrying anything matching "{pat_str}".')
-                return CommandResult.ok()
-            chosen_ally, chosen_entry = matches[0]
-        else:
-            lines = ['', 'Your servants carry:']
-            for i, (a, e) in enumerate(pool, 1):
-                iname = getattr(e.item, 'name', '?')
-                lines.append(f'  {i:>2}. {iname:<24}  (carried by {a.name})')
-            lines.append('')
-            await ctx.send(lines)
-            raw = await ctx.prompt(preamble_lines=f'(1-{len(pool)}, {ctx.player.return_key} to cancel)',
-                                   prompt_text="Take which item")
-            if not raw or not raw.strip():
-                return CommandResult.ok()
-            try:
-                idx = int(raw.strip()) - 1
-                if not (0 <= idx < len(pool)):
-                    raise ValueError
-            except ValueError:
-                await ctx.send('Invalid selection.')
-                return CommandResult.ok()
-            chosen_ally, chosen_entry = pool[idx]
+        choice = await resolve_or_prompt(
+            ctx, choices, args=item_words, prompt_text='Take which item',
+            label_fn=lambda c: f'{c.name:<24}  (carried by {c.owner_name})',
+            list_header='Your servants carry:',
+            no_match_msg=lambda q: f'None of your servants are carrying anything matching "{q}".',
+        )
+        if choice is None:
+            return CommandResult.ok()
 
+        src_ally     = choice.owner
+        chosen_entry = choice.entry
+        iname        = getattr(chosen_entry.item, 'name', 'it')
+
+        # Destination. With another servant available, offer to route the
+        # item straight to them (JoyfulColor's shortcut); with only the
+        # source servant in play, the sole destination is you -- unchanged.
+        others    = [a for a in active if a is not src_ally]
+        dest_ally = None                       # None => the player
+        if others:
+            options = [('yourself', None)] + [(a.name, a) for a in others]
+            picked  = await resolve_or_prompt(
+                ctx, options, args=[], prompt_text='Give to whom',
+                label_fn=lambda o: o[0],
+                list_header='Give to whom?',
+            )
+            if picked is None:
+                return CommandResult.ok()
+            dest_ally = picked[1]
+
+        if dest_ally is not None:
+            return await _reroute_between_allies(
+                ctx, player, src_ally, dest_ally, chosen_entry)
+
+        # --- Take it back into your own pack (the original TAKE) ---
         if inventory and inventory.is_full():
             await ctx.send('You cannot carry any more.')
             return CommandResult.ok()
 
-        iname = getattr(chosen_entry.item, 'name', 'it')
-        chosen_ally.items.remove(chosen_entry)
+        if chosen_entry in src_ally.items:
+            src_ally.items.remove(chosen_entry)
         if inventory:
             inventory.add(chosen_entry.item,
                           quantity=getattr(chosen_entry, 'quantity', 1))
-        await ctx.send(f'{chosen_ally.name} hands you the {iname}.')
+        player.unsaved_changes = True
+        await ctx.send(f'{src_ally.name} hands you the {iname}.')
         # This command had no send_room() at all -- bystanders never saw
         # an item change hands from a servant back to the player.
         # Ryan's request.
         pself = getattr(player, 'name', 'Someone')
         await ctx.send_room(
-            f'{chosen_ally.name} hands {iname} to {pself}.', exclude_self=True)
+            f'{src_ally.name} hands {iname} to {pself}.', exclude_self=True)
         return CommandResult.ok()

--- a/server/commands/take.py
+++ b/server/commands/take.py
@@ -156,10 +156,15 @@ class TakeCommand(Command):
         chosen_entry = choice.entry
         iname        = getattr(chosen_entry.item, 'name', 'it')
 
-        # Destination. With another servant available, offer to route the
-        # item straight to them (JoyfulColor's shortcut); with only the
-        # source servant in play, the sole destination is you -- unchanged.
-        others    = [a for a in active if a is not src_ally]
+        # Destination. The reroute step is for the *browse* forms -- bare
+        # TAKE, or "take from <ally>" -- where you picked the item off a
+        # list, so picking a destination off a list is a natural next
+        # step (JoyfulColor's shortcut). When the item was named outright
+        # ("take sword", "take sword from bob") the player has been
+        # explicit: it goes straight into their own pack, exactly as
+        # before, no extra prompt. And with no other servant to route to,
+        # there's nothing to ask either way.
+        others    = [] if item_words else [a for a in active if a is not src_ally]
         dest_ally = None                       # None => the player
         if others:
             options = [('yourself', None)] + [(a.name, a) for a in others]

--- a/server/inventory_select.py
+++ b/server/inventory_select.py
@@ -201,19 +201,19 @@ def gather_items(
 _UNSET = object()
 
 
-def _default_match(choice: ItemChoice, pattern: str) -> bool:
-    return pattern in (choice.name or '').lower()
+def _default_match(choice, pattern: str) -> bool:
+    return pattern in (getattr(choice, 'name', '') or '').lower()
 
 
 async def resolve_or_prompt(
     ctx,
-    choices: list[ItemChoice],
+    choices: list,
     *,
     args,
     prompt_text: str,
-    label_fn: Callable[[ItemChoice], str],
-    match_fn: Optional[Callable[[ItemChoice, str], bool]] = None,
-    group_fn: Optional[Callable[[ItemChoice], str]] = None,
+    label_fn: Callable[[object], str],
+    match_fn: Optional[Callable[[object, str], bool]] = None,
+    group_fn: Optional[Callable[[object], str]] = None,
     list_header: Optional[str] = None,
     ambiguous_header: str = 'Which one?',
     no_match_msg: Optional[Callable[[str], str]] = None,
@@ -221,6 +221,13 @@ async def resolve_or_prompt(
     auto_select_single: bool = False,
 ) -> Optional[ItemChoice]:
     """Resolve *choices* down to one, by name or by numbered prompt.
+
+    *choices* is usually a list of ItemChoice, but any list of objects
+    works: only *label_fn* (always) and the default *match_fn* (a
+    substring test on `choice.name`) look inside an element, so a list of
+    Ally objects, or of (label, payload) tuples with a custom label_fn,
+    is fine too -- GIVE's "which ally?" and TAKE's "give to whom?" prompts
+    reuse this on non-item lists.
 
     args        -- the raw command args; when non-empty they're joined and
                    matched (case-insensitive, substring) against each

--- a/server/tests/commands/test_give_take.py
+++ b/server/tests/commands/test_give_take.py
@@ -939,6 +939,25 @@ class TestTakeFromAlly(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(self.player.inventory.entries()), 1)
         self.assertNotIn('give to whom', self.ctx.sent().lower())
 
+    async def test_take_named_item_skips_the_destination_step(self):
+        """Even with several servants, naming the item outright
+        ('take <item> from <ally>') goes straight to your own pack -- the
+        reroute step is only for the browse forms."""
+        conan = _make_ally('CONAN')
+        conan.items = [InventoryEntry(item=_make_item('TORCH', item_id=20))]
+        self.player.party.add_member(self.player, conan)
+
+        # A single answer of '2' would pick CONAN as a destination if the
+        # step fired; it must not.
+        self.ctx._prompt_answer = '2'
+        await self.cmd.execute(self.ctx, 'lantern', 'from', 'gandalf')
+
+        self.assertNotIn('give to whom', self.ctx.sent().lower())
+        self.assertEqual(len(self.player.inventory.entries()), 1)
+        self.assertEqual(self.player.inventory.entries()[0].item.name, 'LANTERN')
+        self.assertEqual(len(self.ally.items), 0)                       # left Gandalf
+        self.assertEqual([e.item.name for e in conan.items], ['TORCH'])  # Conan untouched
+
 
 # ---------------------------------------------------------------------------
 # get command no longer aliases 'take'

--- a/server/tests/commands/test_give_take.py
+++ b/server/tests/commands/test_give_take.py
@@ -102,6 +102,14 @@ class _FakeCtx:
         self._sent:  list[str] = []
         self._sent_room: list[str] = []
         self._prompt_answer: str = ''
+        self._prompt_answers: list[str] | None = None
+
+    def set_answers(self, seq) -> None:
+        """Queue a sequence of prompt replies (consumed in order); once
+        exhausted, prompts read as an empty cancel. Use this when a flow
+        asks more than one question -- e.g. bare TAKE's item pick followed
+        by its 'give to whom?' step."""
+        self._prompt_answers = list(seq)
 
     async def send(self, msg, **kwargs):
         if isinstance(msg, list):
@@ -113,6 +121,8 @@ class _FakeCtx:
         self._sent_room.append(str(msg))
 
     async def prompt(self, *args, **kwargs) -> str:
+        if self._prompt_answers is not None:
+            return self._prompt_answers.pop(0) if self._prompt_answers else ''
         return self._prompt_answer
 
     def sent(self) -> str:
@@ -895,11 +905,39 @@ class TestTakeFromAlly(unittest.IsolatedAsyncioTestCase):
         second_ally.items = [InventoryEntry(item=extra_item)]
         self.player.party.add_member(self.player, second_ally)
 
-        self.ctx._prompt_answer = '2'   # pick Conan's torch
+        # Two servants -> a 'give to whom?' step follows the item pick;
+        # answer 1 = "yourself" for the classic take-into-your-own-pack.
+        self.ctx.set_answers(['2', '1'])   # item 2 (Conan's torch), then "yourself"
         await self.cmd.execute(self.ctx)
         entries = self.player.inventory.entries()
         self.assertEqual(len(entries), 1)
         self.assertEqual(entries[0].item.name, 'TORCH')
+
+    async def test_take_reroutes_item_from_one_ally_to_another(self):
+        """Two servants: pick an item off one, hand it straight to the
+        other -- it never touches the player's inventory."""
+        conan      = _make_ally('CONAN')
+        torch      = _make_item('TORCH', item_id=20)
+        conan.items = [InventoryEntry(item=torch)]
+        self.player.party.add_member(self.player, conan)
+
+        # item 1 = Gandalf's LANTERN; destination 2 = CONAN
+        self.ctx.set_answers(['1', '2'])
+        await self.cmd.execute(self.ctx)
+
+        self.assertEqual(len(self.player.inventory.entries()), 0)
+        self.assertEqual(len(self.ally.items), 0)          # left Gandalf
+        conan_item_names = [e.item.name for e in conan.items]
+        self.assertIn('LANTERN', conan_item_names)         # arrived at Conan
+        self.assertIn('CONAN', self.ctx.sent().upper())
+        self.assertTrue(self.player.unsaved_changes)
+
+    async def test_take_single_servant_still_goes_straight_to_you(self):
+        """One servant -> no 'give to whom?' step, unchanged behaviour."""
+        self.ctx._prompt_answer = '1'
+        await self.cmd.execute(self.ctx, 'from', 'gandalf')
+        self.assertEqual(len(self.player.inventory.entries()), 1)
+        self.assertNotIn('give to whom', self.ctx.sent().lower())
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Builds on #41 (`feature/inventory-select`) — merge that first; this branch is stacked on it.

## What

Moves the last two item commands, **GIVE** and **TAKE**, onto the shared `inventory_select` helper, and adds the shortcut JoyfulColor asked for: bare **TAKE** can hand an item from one ally straight to another, skipping the take-it-to-yourself-then-give-it-on shuffle.

## GIVE

- Item pick (name match, or the numbered "Items you carry:" menu) → `gather_items(player)` + `resolve_or_prompt(...)`.
- The no-target **"give to whom?"** ally pick also goes through `resolve_or_prompt` — it lists `Ally` objects directly, since the helper only ever reads `.name` / `label_fn` off a list element.
- All the delivery logic (weapon-stow, ammo-load, armor-wear, mount capacity, body-building, give-to-player, give-to-monster) is untouched.
- **Behaviour change:** naming a fragment that matches several items now opens a "Which one?" sub-prompt instead of silently giving the first match (same change USE got in #41).
- Fixes the long-failing `test_give_no_target_asks_whom` as a side effect — it checked the output for "whom", and the old header was "Give to which ally:".

## TAKE

- The servant-pack pool is now `gather_items(include_player=False, include_allies=True, allies=<servants>)`; the item pick is one `resolve_or_prompt(...)`.
- **New destination step:** when the party has **two or more servants**, the item pick is followed by a "give to whom?" list — `yourself` plus every *other* servant.
  - `yourself` → the original take-into-your-pack path.
  - another ally → `_reroute_between_allies()` moves the item straight from one pack to the other, never touching your inventory.
- **One servant → no extra prompt**, behaviour unchanged.
- The ally→ally hop is a **plain relocation** — no auto-ready / auto-wear / ammo-load. Those model *the player* equipping an ally; a reshuffle between allies just moves cargo, and READY/UNREADY already work on either ally's pack (from #41). Mount saddlebag-capacity is still enforced on the destination.
- TAKE-to-yourself now sets `player.unsaved_changes` (it didn't before — the same persistence gap GIVE's branches were fixed for).

```
take

Your servants carry:
   1. LONG SWORD             (carried by Alan)
   2. TORCH                  (carried by Bo)

Take which item: 1

Give to whom?
   1. yourself
   2. Bo

Give to whom: 2
Alan hands the LONG SWORD to Bo.
```

## Helper tweak

`resolve_or_prompt()`'s type hints and docstring loosen from `ItemChoice` to "any labelled object"; the default `match_fn` now reads `getattr(choice, 'name', '')` so a bare object can't crash it. This is what lets GIVE's "which ally?" and TAKE's "give to whom?" reuse it.

## Tests

- `_FakeCtx` gains `set_answers([...])` for flows that ask more than one question.
- `test_take_bare_command_shows_all_allies` answers the new destination step with "yourself".
- New: `test_take_reroutes_item_from_one_ally_to_another`, `test_take_single_servant_still_goes_straight_to_you`.
- `test_give_take.py`: 82 passed. Full suite: 1 pre-existing unrelated failure (`test_get_unconscious` — a "skuttles"/"scuttles" string assertion), same as on `master`.

## Net

`give.py` −16, `take.py` reworked (+40 for the destination step / reroute helper), `test_give_take.py` +40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UgzkSgmKtqBeHM9pc771KH
