### PR TITLE
Buffered More-Prompt: decide pagination once per turn (clean re-land of #30)

### DIFF
--- a/server/network_context.py
+++ b/server/network_context.py
@@ -102,6 +102,13 @@ class BaseContext:
                      preamble_lines: list[str] | None = None) -> str:
         raise NotImplementedError
 
+    async def flush_turn(self, *, paginate: bool = True) -> None:
+        """Emit any output buffered during the current turn. No-op by
+        default; GameContext overrides it to make the combined-output
+        "-- More --" pagination decision. Safe to call on any context so
+        the server loop needn't special-case the transport."""
+        return None
+
     def _pop_pending_pages(self) -> list[str]:
         """Pop and format any pages queued while this player was busy (in
         combat -- see commands/messaging.py's is_in_combat() and
@@ -142,16 +149,43 @@ class GameContext(BaseContext):
 
     _prompt: str = field(default='> ', repr=False)
 
+    # --- Per-turn output buffering (see flush_turn) -----------------------
+    # send() accumulates a turn's output here instead of sending each call
+    # immediately, so the "-- More --" pagination decision is made once
+    # against the cumulative total rather than per send() call. See
+    # ALPHA_TESTERS.md, "More Prompt doesn't trigger when output is split
+    # across separate send() calls".
+    #
+    # Plain class attributes rather than dataclass fields on purpose: a few
+    # tests build a context via GameContext.__new__() without running
+    # __init__, and prompt()/send() must still work then (buffer just stays
+    # inert). _turn_buffer is lazily replaced with a per-instance list on
+    # first use, so the None default is never mutated.
+    _turn_buffer = None
+    _in_turn     = False   # armed by prompt() while a command runs
+    _paginating  = False   # guard: _paginate()'s own prompts don't re-buffer
+    _buffering_enabled = False   # set True once in the game loop; login/negotiation
+                                 # output keeps its old immediate-send behavior
+                                 # (it has its own e2e pagination-drain helpers)
+
     # -----------------------------------------------------------------------
     # Core I/O
     # -----------------------------------------------------------------------
 
-    async def send(self, *lines) -> None:
+    async def send(self, *lines, flush: bool = False) -> None:
         """
         Format and send text to this player over the JSON wire.
         Lines are word-wrapped and bracket-highlighted for this player's
         terminal settings before being packed into a Message.
         Automatically paginates when output exceeds the player's screen height.
+
+        While a command is running (self._in_turn, armed by prompt()) the
+        formatted lines are appended to a per-turn buffer instead of being
+        sent right away; the buffer is flushed -- and the pagination
+        decision made against its cumulative length -- at the next prompt()
+        or an explicit flush_turn(). Pass flush=True to force this call
+        (and anything already buffered) out immediately, e.g. for a
+        long-running command that wants incremental output while it runs.
         """
         from formatting import (
             format_lines, codec_for_settings, flatten_send_args,
@@ -166,11 +200,45 @@ class GameContext(BaseContext):
         elif isinstance(codec, PlainCodec):
             formatted = plain_encode_lines(formatted)
 
+        if self._in_turn and not self._paginating:
+            if self._turn_buffer is None:
+                self._turn_buffer = []
+            self._turn_buffer.extend(formatted)
+            if flush:
+                await self.flush_turn()
+            return
+        await self._emit(formatted)
+
+    async def _emit(self, formatted: list[str]) -> None:
+        """Send formatted lines now, paginating if they exceed a screenful
+        and More Prompt is on. The single choke point both send() (when not
+        buffering) and flush_turn() funnel through."""
         page_size = max(1, self.player.client_settings.screen_rows - 1)
         if self._wants_pagination(formatted, page_size):
             await self._paginate(formatted, page_size)
         else:
             await self._send_formatted(formatted)
+
+    async def flush_turn(self, *, paginate: bool = True) -> None:
+        """Emit everything send() buffered during this turn as one combined
+        block, so the "-- More --" pagination decision is made against the
+        cumulative total instead of per send() call (ALPHA_TESTERS.md:
+        "More Prompt doesn't trigger when output is split across separate
+        send() calls").
+
+        Called at the natural end-of-turn points: the top of prompt(), and
+        explicitly after each command dispatch in simple_server's login /
+        game loops. paginate=False drains the buffer without ever showing a
+        More prompt -- used on the disconnect path, where blocking for a
+        keypress on a closing socket makes no sense.
+        """
+        if not self._turn_buffer:
+            return
+        buf, self._turn_buffer = self._turn_buffer, []
+        if paginate:
+            await self._emit(buf)
+        else:
+            await self._send_formatted(buf)
 
     def _wants_pagination(self, formatted: list[str], page_size: int) -> bool:
         """Whether output should pause between screenfuls (PlayerFlags.MORE_PROMPT)
@@ -204,6 +272,13 @@ class GameContext(BaseContext):
         B or -        — previous page
         Q             — stop reading early
         """
+        self._paginating = True   # our own prompt() calls below must not re-buffer or re-flush
+        try:
+            await self._paginate_loop(formatted, page_size)
+        finally:
+            self._paginating = False
+
+    async def _paginate_loop(self, formatted: list[str], page_size: int) -> None:
         total      = len(formatted)
         total_pgs  = max(1, (total + page_size - 1) // page_size)
         idx        = 0
@@ -283,6 +358,15 @@ class GameContext(BaseContext):
         if preamble_lines:
             await self.send(preamble_lines)
 
+        # End of the previous turn: flush its buffered output (deciding
+        # pagination against the cumulative total) and disarm buffering
+        # while we block for input, so out-of-band sends from other players
+        # (say/page/wall) still reach this client immediately. _paginate()'s
+        # own prompt() calls set self._paginating and skip all of this.
+        if not self._paginating:
+            await self.flush_turn()
+            self._in_turn = False
+
         from tada_utilities import substitute_tokens
         prompt_text = substitute_tokens(prompt_text, self.player)
 
@@ -300,14 +384,23 @@ class GameContext(BaseContext):
             if isinstance(obj, dict):
                 lines = obj.get('lines')
                 if isinstance(lines, list) and lines:
-                    return str(lines[0]).strip()
-                return str(obj.get('text', '')).strip()
-            return ''
+                    text = str(lines[0]).strip()
+                else:
+                    text = str(obj.get('text', '')).strip()
+            else:
+                text = ''
         except asyncio.IncompleteReadError:
             return None         # EOF mid-stream — client dropped
         except Exception:
             logging.exception('GameContext.prompt: error reading response')
             return None         # treat unrecoverable errors as disconnect
+
+        # Got real input: arm buffering so the resulting command's send()
+        # calls accumulate into one screenful-aware block. Only in the game
+        # loop -- login/negotiation output streams immediately as before.
+        if not self._paginating and self._buffering_enabled:
+            self._in_turn = True
+        return text
 
     # -----------------------------------------------------------------------
     # Helpers
@@ -411,20 +504,26 @@ class PETSCIINetworkContext(GameContext):
     LINE_ENDING: bytes = b'\r'          # Commodore CR
     CODEC_NAME:  str   = 'petscii_c64en_lc'
 
-    async def send(self, *lines) -> None:
+    async def send(self, *lines, flush: bool = False) -> None:
         """Encode and send as raw PETSCII bytes — no JSON envelope.
-        Automatically paginates when output exceeds the player's screen height."""
+        Automatically paginates when output exceeds the player's screen height.
+
+        Like GameContext.send(): buffers into the per-turn buffer while a
+        command runs (see flush_turn); flush=True forces it out now."""
         from formatting import codec_for_settings
         from tada_utilities import substitute_tokens
         raw       = [substitute_tokens(line, self.player) for line in flatten_send_args(*lines)]
         codec     = codec_for_settings(self.player.client_settings)
         formatted = format_lines(raw, self.player.client_settings, codec)
 
-        page_size = max(1, self.player.client_settings.screen_rows - 1)
-        if self._wants_pagination(formatted, page_size):
-            await self._paginate(formatted, page_size)
-        else:
-            await self._send_formatted(formatted)
+        if self._in_turn and not self._paginating:
+            if self._turn_buffer is None:
+                self._turn_buffer = []
+            self._turn_buffer.extend(formatted)
+            if flush:
+                await self.flush_turn()
+            return
+        await self._emit(formatted)
 
     def _text_codec_name(self) -> str:
         """Codec name for encoding this player's outgoing text.
@@ -503,6 +602,12 @@ class PETSCIINetworkContext(GameContext):
             preamble_lines = pending + list(preamble_lines or [])
         if preamble_lines:
             await self.send(preamble_lines)
+        # End of the previous turn -- see GameContext.prompt() for the full
+        # rationale: flush its buffered output as one screenful-aware block,
+        # then disarm buffering while we block for input.
+        if not self._paginating:
+            await self.flush_turn()
+            self._in_turn = False
         from tada_utilities import substitute_tokens
         prompt_text = substitute_tokens(prompt_text, self.player)
         if self.player.query_flag(PlayerFlags.HOURGLASS):
@@ -537,6 +642,8 @@ class PETSCIINetworkContext(GameContext):
             # from formatting import petscii_encode
             # self.writer.write(petscii_encode(text, self.CODEC_NAME) + self.LINE_ENDING)
             # await self.writer.drain()
+            if not self._paginating and self._buffering_enabled:
+                self._in_turn = True   # arm buffering for the resulting command (game loop only)
             return text
         except asyncio.IncompleteReadError:
             return None         # EOF — Commodore client disconnected

--- a/server/simple_server.py
+++ b/server/simple_server.py
@@ -403,6 +403,13 @@ class Server:
         finally:
             if addr in self.clients:
                 del self.clients[addr]
+            # Drain any output a turn buffered but never flushed because an
+            # exception unwound past the normal end-of-dispatch flush.
+            # paginate=False: never block for a keypress on a closing socket.
+            try:
+                await ctx.flush_turn(paginate=False)
+            except Exception:
+                pass
             # combat/duel.py's DuelSession.forfeit(): a duelist who
             # disconnects mid-fight (crash, abrupt close, or a graceful
             # quit) is treated as an automatic loss, mirroring
@@ -753,6 +760,11 @@ class Server:
     async def _game_loop(self, ctx: GameContext) -> None:
         """Main command loop for an authenticated (or guest) player."""
         logging.debug('ENTER')
+        # From here on, ctx.send() buffers a turn's output and defers the
+        # More-Prompt pagination decision to the combined total (see
+        # network_context.flush_turn). Login/negotiation output above stays
+        # on the old immediate-send path.
+        ctx._buffering_enabled = True
         if not getattr(ctx.client, 'room', None):
             ctx.client.room = int(getattr(ctx.player, 'map_room', 1) or 1)
 
@@ -783,6 +795,12 @@ class Server:
             from datetime import datetime
             ctx.client.last_input = datetime.now()
             result = await processor.process_input(raw, ctx=ctx)
+            # End of dispatch: flush this turn's buffered send() output as
+            # one screenful-aware block (see network_context.flush_turn).
+            # Covers command paths that return without a further prompt
+            # (e.g. 'quit'); the normal path re-flushes harmlessly at the
+            # next ctx.prompt('main').
+            await ctx.flush_turn()
 
             # QuitCommand sets data={'quit': True} to signal clean exit
             if result.data.get('quit'):

--- a/server/tests/client/test_more_prompt.py
+++ b/server/tests/client/test_more_prompt.py
@@ -147,6 +147,132 @@ class TestPaginatePromptText(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(prompt_text, '-- More [1/3] [?=help] --')
 
 
+class TestTurnBuffering(unittest.IsolatedAsyncioTestCase):
+    """ALPHA_TESTERS.md: "More Prompt doesn't trigger when output is split
+    across separate send() calls". While a command runs (ctx._in_turn),
+    send() accumulates into a per-turn buffer and the pagination decision
+    is deferred to flush_turn(), which sees the cumulative total."""
+
+    async def test_send_buffers_while_in_turn(self):
+        ctx = _make_ctx(more_prompt=True)
+        ctx._in_turn = True
+        await ctx.send(*[f'line {i}' for i in range(20)])
+        ctx._paginate.assert_not_awaited()
+        ctx._send_formatted.assert_not_awaited()
+        self.assertEqual(len(ctx._turn_buffer), 20)
+
+    async def test_send_emits_immediately_when_not_in_turn(self):
+        # Default (freshly constructed) context is not in a turn: today's
+        # behavior, one send() decides its own pagination.
+        ctx = _make_ctx(more_prompt=True)
+        await ctx.send(*[f'line {i}' for i in range(20)])
+        ctx._paginate.assert_awaited_once()
+
+    async def test_two_short_sends_paginate_once_combined(self):
+        # page_size is 9 (screen_rows 10). Two 6-line sends each stay under
+        # it, but 12 combined exceeds it -> flush_turn paginates once.
+        ctx = _make_ctx(more_prompt=True)
+        ctx._in_turn = True
+        await ctx.send(*[f'help {i}' for i in range(6)])
+        await ctx.send(*[f'menu {i}' for i in range(6)])
+        ctx._paginate.assert_not_awaited()
+        await ctx.flush_turn()
+        ctx._paginate.assert_awaited_once()
+        (lines, _page_size), _ = ctx._paginate.await_args
+        self.assertEqual(len(lines), 12)
+
+    async def test_flush_turn_below_page_size_does_not_paginate(self):
+        ctx = _make_ctx(more_prompt=True)
+        ctx._in_turn = True
+        await ctx.send('a', 'b', 'c')
+        await ctx.flush_turn()
+        ctx._paginate.assert_not_awaited()
+        ctx._send_formatted.assert_awaited_once()
+
+    async def test_flush_turn_paginate_false_never_paginates(self):
+        ctx = _make_ctx(more_prompt=True)
+        ctx._in_turn = True
+        await ctx.send(*[f'line {i}' for i in range(50)])
+        await ctx.flush_turn(paginate=False)
+        ctx._paginate.assert_not_awaited()
+        ctx._send_formatted.assert_awaited_once()
+
+    async def test_flush_true_forces_buffer_out_mid_turn(self):
+        ctx = _make_ctx(more_prompt=True)
+        ctx._in_turn = True
+        await ctx.send('buffered first')
+        await ctx.send('now flush', flush=True)
+        ctx._send_formatted.assert_awaited_once()
+        (lines,), _ = ctx._send_formatted.await_args
+        self.assertEqual(lines, ['buffered first', 'now flush'])
+        self.assertEqual(ctx._turn_buffer, [])
+
+    async def test_flush_turn_noop_on_empty_buffer(self):
+        ctx = _make_ctx(more_prompt=True)
+        ctx._in_turn = True
+        await ctx.flush_turn()
+        ctx._paginate.assert_not_awaited()
+        ctx._send_formatted.assert_not_awaited()
+
+    async def test_send_during_pagination_is_not_re_buffered(self):
+        # _paginate() sets _paginating; its own status-line sends must go
+        # straight out, not back into the buffer it is draining.
+        ctx = _make_ctx(more_prompt=True)
+        ctx._in_turn = True
+        ctx._paginating = True
+        await ctx.send('status line')
+        ctx._send_formatted.assert_awaited_once()
+        self.assertIsNone(ctx._turn_buffer)
+
+
+class TestPromptFlushesAndArmsTurn(unittest.IsolatedAsyncioTestCase):
+    """prompt() is the natural end-of-turn hook: it flushes the previous
+    turn's buffer, disarms buffering while blocked for input, then re-arms
+    it once real input arrives so the next command's send()s accumulate."""
+
+    def _ctx(self, response=b'{"lines": ["look"]}\n'):
+        from unittest.mock import MagicMock
+        player = _FakePlayer(more_prompt=True)
+        ctx = GameContext(player=player, reader=MagicMock(), writer=MagicMock(),
+                          server=MagicMock(), client=MagicMock())
+        ctx._buffering_enabled = True   # simple_server sets this on entering the game loop
+        ctx.server.send_message = AsyncMock()
+        ctx.reader.readline = AsyncMock(return_value=response)
+        ctx._send_formatted = AsyncMock()
+        ctx._paginate = AsyncMock()
+        return ctx
+
+    async def test_prompt_flushes_buffer_then_arms_in_turn(self):
+        ctx = self._ctx()
+        ctx._in_turn = True
+        await ctx.send('leftover from last turn')
+        self.assertEqual(len(ctx._turn_buffer), 1)
+
+        result = await ctx.prompt('main')
+
+        self.assertEqual(result, 'look')
+        ctx._send_formatted.assert_awaited()          # buffer was flushed
+        self.assertEqual(ctx._turn_buffer, [])
+        self.assertTrue(ctx._in_turn)                 # re-armed for next command
+
+    async def test_prompt_disarms_in_turn_on_disconnect(self):
+        ctx = self._ctx(response=b'')                 # EOF
+        ctx._in_turn = True
+        result = await ctx.prompt('main')
+        self.assertIsNone(result)
+        self.assertFalse(ctx._in_turn)
+
+    async def test_prompt_does_not_arm_when_buffering_disabled(self):
+        # Login / terminal-negotiation phase: buffering stays off so that
+        # output streams immediately and never paginates mid-login (the
+        # e2e helpers only drain the pre-login banner's pages).
+        ctx = self._ctx()
+        ctx._buffering_enabled = False
+        result = await ctx.prompt('login')
+        self.assertEqual(result, 'look')
+        self.assertFalse(ctx._in_turn)
+
+
 class TestToggleMorePrompt(unittest.IsolatedAsyncioTestCase):
 
     async def test_toggle_off_from_on(self):


### PR DESCRIPTION
Clean re-land of #30.

## Why a new PR

#30's merge (`ea2f4d7`) was force-reset off `master`: its branch
`feature/buffered-more-prompt` was stale and had ~4 MB of committed
artifacts (`screenlog.0`, `client.log.2026-08-2x`, `dotbasic-v2.2.zip`,
hardcopies, `tada_screen_dump*.txt`) plus an unrelated `helpstaff` command
and assembly-client files — all of which rode onto master as a side effect
of the merge. The commit is preserved locally as tag `pre-30-cleanup` for
anyone who wants those files re-landed on their own PRs.

## What this PR contains

Only the three actual feature files:

- `server/network_context.py` (+129) — `flush_turn()`; buffer a turn's
  `ctx.send()` output and make the More-Prompt pagination decision once on
  the combined total instead of per send.
- `server/simple_server.py` (+18) — `_game_loop()` sets
  `ctx._buffering_enabled` on entry and calls `ctx.flush_turn()` at end of
  dispatch (covers command paths that return without a further prompt, e.g.
  `quit`). Login/negotiation output stays on the immediate-send path.
- `server/tests/client/test_more_prompt.py` (+126) — coverage.

The branch's own `tests/conftest.py` change from #30 is intentionally
dropped — it was a duplicate fix for the post-login pagination race that
`master`'s `c8cde24` already handles.

## Testing

`pytest -q -m "" tests/client/test_more_prompt.py tests/client/test_prefs_more_prompt.py tests/e2e tests/movement/test_move_south_room1.py` → 95 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)