### PR TITLE
Fix stale 'skuttles' typo in test_get_unconscious.py

### DIFF
--- a/server/tests/commands/test_get_unconscious.py
+++ b/server/tests/commands/test_get_unconscious.py
@@ -1,7 +1,7 @@
 """tests/commands/test_get_unconscious.py
 
 Covers commands/get.py's `_try_get_living()` player-target branch
-(SPUR.MISC.S get.plyr): GETting a conscious player says "skuttles out
+(SPUR.MISC.S get.plyr): GETting a conscious player says "scuttles out
 of reach!"; GETting an Unconscious one (PlayerFlags.UNCONSCIOUS -- a
 duel loss, see combat/duel.py's DuelSession._end()) says "won't fit in
 your sack.." instead (sentence-case per this port's convention, not
@@ -37,7 +37,7 @@ def _make_ctx(viewer, room_no, other_clients):
 
 
 class TestGetLivingPlayerTarget(unittest.IsolatedAsyncioTestCase):
-    async def test_conscious_player_skuttles_out_of_reach(self):
+    async def test_conscious_player_scuttles_out_of_reach(self):
         viewer = Player(name='Rulan')
         target = Player(name='Belwin')
         other_client = _room_client(target)
@@ -45,7 +45,7 @@ class TestGetLivingPlayerTarget(unittest.IsolatedAsyncioTestCase):
 
         await GetCommand()._try_get_living(ctx, 'belwin')
         sent = '\n'.join(str(a) for call in ctx.send.await_args_list for a in call.args)
-        self.assertIn('skuttles out of reach', sent.lower())
+        self.assertIn('scuttles out of reach', sent.lower())
         self.assertNotIn("won't fit", sent.lower())
 
     async def test_unconscious_player_wont_fit_in_sack(self):
@@ -58,7 +58,7 @@ class TestGetLivingPlayerTarget(unittest.IsolatedAsyncioTestCase):
         await GetCommand()._try_get_living(ctx, 'belwin')
         sent = '\n'.join(str(a) for call in ctx.send.await_args_list for a in call.args)
         self.assertIn("won't fit in your sack", sent.lower())
-        self.assertNotIn('skuttles', sent.lower())
+        self.assertNotIn('scuttles', sent.lower())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
`commands/get.py:481` was corrected to `"scuttles out of reach!"` back in
`09c0544`, but `tests/commands/test_get_unconscious.py` still asserted the
old `skuttles` spelling (plus the stale spelling in its docstring and
method name). This was the lone failure in a full `pytest -m ""` run on
master:

```
FAILED tests/commands/test_get_unconscious.py::TestGetLivingPlayerTarget::test_conscious_player_skuttles_out_of_reach
  AssertionError: 'skuttles out of reach' not found in 'belwin scuttles out of reach!'
```

Cherry-picked from Ryan's existing commit `79b9c68` on the `prefs`
branch (which is otherwise fully absorbed into master — this was its only
remaining unmerged change). Test-only, 4 lines.

`pytest -q tests/commands/test_get_unconscious.py` → 2 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)