### PR TITLE
Dwarf: reset hoard to a 500-silver floor on kill, not zero

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -47,7 +47,8 @@ SETTINGS_METADATA: Dict[str, SettingInfo] = {
         'Victory Item',
     ),
     'dwarf_silver': SettingInfo(
-        int, 'Silver The Dwarf (tips.txt) has stolen so far, server-wide. Awarded in full to whoever kills him.',
+        int, "Silver The Dwarf (tips.txt) has stolen so far, server-wide. Awarded in full to "
+        "whoever kills him, then reset to a 500-silver floor (not zero).",
         "Dwarf's Silver",
     ),
     'dwarf_move_interval_minutes': SettingInfo(

--- a/server/encounters/dwarf.py
+++ b/server/encounters/dwarf.py
@@ -15,7 +15,8 @@ SPUR source:
     preferentially the win-condition item if carried, else a random one.
     No-op in water/vacuum ("@@") rooms.
   - SPUR.MISC.S:385-388 ("p.a4"): on death, awards his entire accumulated
-    hoard to the killer and resets it to 0.
+    hoard to the killer and resets it to a 500-gold floor (dh=0:dl=500),
+    not zero -- so an immediate re-kill still nets something.
 
 Deviates from SPUR (Ryan's explicit request, not a ported mechanic): the
 original places the Dwarf once at world-init and never relocates him
@@ -362,7 +363,9 @@ async def on_killed(ctx: 'GameContext') -> list[str]:
         current = player.get_silver(PlayerMoneyTypes.IN_HAND)
         player.set_silver_absolute(PlayerMoneyTypes.IN_HAND, current + hoard)
         player.unsaved_changes = True
-    config.dwarf_silver = 0
+    # SPUR.MISC.S "p.a3": dh=0:dl=500 -- the hoard resets to a 500 floor,
+    # not zero, so an unlucky immediate re-kill still nets something.
+    config.dwarf_silver = 500
     ctx.player.clear_flag(PlayerFlags.DWARF_ALIVE)
 
     game_map = getattr(ctx.server, 'game_map', None)

--- a/server/encounters/dwarf.py
+++ b/server/encounters/dwarf.py
@@ -15,7 +15,7 @@ SPUR source:
     preferentially the win-condition item if carried, else a random one.
     No-op in water/vacuum ("@@") rooms.
   - SPUR.MISC.S:385-388 ("p.a4"): on death, awards his entire accumulated
-    hoard to the killer and resets it to a 500-gold floor (dh=0:dl=500),
+    hoard to the killer and resets it to a 500-silver floor (dh=0:dl=500),
     not zero -- so an immediate re-kill still nets something.
 
 Deviates from SPUR (Ryan's explicit request, not a ported mechanic): the
@@ -363,8 +363,8 @@ async def on_killed(ctx: 'GameContext') -> list[str]:
         current = player.get_silver(PlayerMoneyTypes.IN_HAND)
         player.set_silver_absolute(PlayerMoneyTypes.IN_HAND, current + hoard)
         player.unsaved_changes = True
-    # SPUR.MISC.S "p.a3": dh=0:dl=500 -- the hoard resets to a 500 floor,
-    # not zero, so an unlucky immediate re-kill still nets something.
+    # SPUR.MISC.S "p.a3": dh=0:dl=500 -- the hoard resets to a 500-silver
+    # floor, not zero, so an unlucky immediate re-kill still nets something.
     config.dwarf_silver = 500
     ctx.player.clear_flag(PlayerFlags.DWARF_ALIVE)
 

--- a/server/tests/combat/test_dwarf.py
+++ b/server/tests/combat/test_dwarf.py
@@ -342,7 +342,7 @@ class TestOnKilled(unittest.IsolatedAsyncioTestCase):
                     net_common.run_server_dir = orig_dir
 
             self.assertEqual(player.get_silver('IN_HAND'), 850)
-            self.assertEqual(config.dwarf_silver, 0)
+            self.assertEqual(config.dwarf_silver, 500)
             player.clear_flag.assert_called_once_with(PlayerFlags.DWARF_ALIVE)
             self.assertEqual(game_map.get_room(1, 2).monster, 0)
             self.assertIn('750', lines[0])


### PR DESCRIPTION
Ports SPUR.MISC.S's original `dh=0:dl=500` payout logic. The port had been
zeroing the Dwarf's hoard on death, so a player who kills him right after
someone else has already drained it got **nothing**. With the floor, an
unlucky immediate re-kill still nets a guaranteed 500 silver.

- `encounters/dwarf.py` — `config.dwarf_silver = 500` (was `0`) in
  `on_killed()`, plus docstring/comment updates.
- `config.py` — `dwarf_silver` setting description notes the 500 floor.
- `tests/combat/test_dwarf.py` — assertion updated; 18 pass.

## Provenance

`96b93cd` is the original `05ddbbe`, which had been sitting as a shared
base commit under `feature/ooc` / `feature/say-verb-switch` / `feature/pose`
(all since merged without it). Cherry-picked onto its own branch during the
2026-09-09 cleanup; `296a0c5` is a follow-up fixing two "gold" → "silver"
comments to match the port's silver-standard convention (the `config.py`
half already said "silver"). Rebased onto current master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)