### PR TITLE
Add #reply / #r and #last to page and whisper; namespace command_settings.page/.whisper

### DIFF
--- a/server/command_settings.py
+++ b/server/command_settings.py
@@ -100,18 +100,65 @@ class SaySettings:
 
 
 @dataclass
+class PageSettings:
+    """commands/page.py preferences, namespaced as command_settings.page.
+
+    haven: True blocks ALL incoming pages ('page #haven' / 'page #unhaven').
+
+    ignored_pagers: names blocked from paging this player ('page #ignore
+    <name>' / 'page #unignore <name>'); stored with original casing,
+    compared case-insensitively.
+
+    last_paged: the other party in your most recent page exchange, for the
+    'page #reply' / 'page #r' target token -- set both when you send a page
+    and when you receive one. Original casing; None until the first page
+    either way.
+
+    history: 'page #last' recent-recipient log -- a list of
+    {'name': str, 'at': isoformat-str} dicts, most recent first, de-duped
+    by name, capped at 10 (commands/messaging.py's record_message_target()
+    / render_last_history()).
+
+    last_limit: how many lines 'page #last' shows, 1..10 ('page #last N'
+    sets it).
+    """
+    haven: bool = False
+    ignored_pagers: list = field(default_factory=list)
+    last_paged: Optional[str] = None
+    history: list = field(default_factory=list)
+    last_limit: int = 5
+
+
+@dataclass
+class WhisperSettings:
+    """commands/whisper.py preferences, namespaced as command_settings.whisper.
+
+    last_whispered: the other party in your most recent whisper exchange,
+    for the 'whisper #reply' / 'whisper #r' target token -- set both when
+    you send a whisper and when you receive one. Original casing; None
+    until the first whisper either way.
+
+    history / last_limit: as PageSettings, but for 'whisper #last'.
+    """
+    last_whispered: Optional[str] = None
+    history: list = field(default_factory=list)
+    last_limit: int = 5
+
+
+@dataclass
 class CommandSettings:
     """Player-controlled command preferences."""
     whereat_hidden: bool = False
     # Named groups for whisper/page: group_name (lower) → list of player names
     groups: dict = field(default_factory=dict)
-    # PAGE command preferences (commands/page.py)
-    # True: block ALL incoming pages ('page #haven' / 'page #unhaven').
-    haven: bool = False
-    # Names blocked from paging this player ('page #ignore <name>' /
-    # 'page #unignore <name>'); stored with original casing, compared
-    # case-insensitively.
-    ignored_pagers: list = field(default_factory=list)
+    # PAGE command preferences: haven, ignored_pagers, #reply target,
+    # #last history/limit (commands/page.py). Was a set of flat
+    # CommandSettings fields (haven, ignored_pagers) -- from_dict() still
+    # reads those from older save files.
+    page: PageSettings = field(default_factory=PageSettings)
+    # WHISPER command preferences: #reply target, #last history/limit
+    # (commands/whisper.py).
+    whisper: WhisperSettings = field(default_factory=WhisperSettings)
     # Tip-of-the-day cycling/display preference (commands/tips.py, tips.py)
     tips: TipsSettings = field(default_factory=TipsSettings)
     # Threaded message board preferences (board.py, commands/board.py)
@@ -126,14 +173,6 @@ class CommandSettings:
     # 'say' preferences: comma-split dialogue attribution, custom verb
     # override (commands/say.py)
     say: SaySettings = field(default_factory=SaySettings)
-    # Last correspondent on each private channel, for the '#reply' / '#r'
-    # target token (commands/page.py, commands/whisper.py). Updated both
-    # when you send on that channel and when you receive on it, so
-    # 'page #r=...' / 'whisper #r=...' always points at the other party in
-    # the most recent exchange. Stored with original casing; None until
-    # the first page/whisper either way.
-    last_paged: Optional[str] = None
-    last_whispered: Optional[str] = None
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -146,6 +185,8 @@ class CommandSettings:
         news_data = known.pop('news', None)
         teleport_data = known.pop('teleport', None)
         say_data = known.pop('say', None)
+        page_data = known.pop('page', None)
+        whisper_data = known.pop('whisper', None)
         instance = cls(**known)
         if isinstance(tips_data, dict):
             instance.tips = TipsSettings(**{
@@ -173,5 +214,26 @@ class CommandSettings:
             instance.say = SaySettings(**{
                 k: v for k, v in say_data.items()
                 if k in SaySettings.__dataclass_fields__
+            })
+        if isinstance(page_data, dict):
+            instance.page = PageSettings(**{
+                k: v for k, v in page_data.items()
+                if k in PageSettings.__dataclass_fields__
+            })
+        else:
+            # Back-compat: 'haven' and 'ignored_pagers' used to be flat
+            # CommandSettings fields before the command_settings.page
+            # namespace existed -- fold an older save file's values in.
+            legacy = {}
+            if 'haven' in data:
+                legacy['haven'] = data['haven']
+            if 'ignored_pagers' in data:
+                legacy['ignored_pagers'] = list(data['ignored_pagers'] or [])
+            if legacy:
+                instance.page = PageSettings(**legacy)
+        if isinstance(whisper_data, dict):
+            instance.whisper = WhisperSettings(**{
+                k: v for k, v in whisper_data.items()
+                if k in WhisperSettings.__dataclass_fields__
             })
         return instance

--- a/server/command_settings.py
+++ b/server/command_settings.py
@@ -126,6 +126,14 @@ class CommandSettings:
     # 'say' preferences: comma-split dialogue attribution, custom verb
     # override (commands/say.py)
     say: SaySettings = field(default_factory=SaySettings)
+    # Last correspondent on each private channel, for the '#reply' / '#r'
+    # target token (commands/page.py, commands/whisper.py). Updated both
+    # when you send on that channel and when you receive on it, so
+    # 'page #r=...' / 'whisper #r=...' always points at the other party in
+    # the most recent exchange. Stored with original casing; None until
+    # the first page/whisper either way.
+    last_paged: Optional[str] = None
+    last_whispered: Optional[str] = None
 
     def to_dict(self) -> dict:
         return asdict(self)

--- a/server/commands/editplayer.py
+++ b/server/commands/editplayer.py
@@ -760,6 +760,52 @@ def _command_settings_menu(ctx) -> Menu:
         dot_leader_handler=lambda ctx: (p.command_settings.news.last_read or '(never)')[:10],
         action=edit_news_last_read,
     ))
+
+    # last_paged / last_whispered: the target for the '#reply' / '#r' token
+    # in commands/page.py and commands/whisper.py -- normally maintained by
+    # those commands themselves (set on both send and receive). Editable
+    # here so an admin can point a player's reply target at someone else or
+    # clear a stale one.
+    async def _edit_reply_target(ctx, field: str, label: str) -> None:
+        from tada_utilities import find_players, player_exists
+
+        cs      = p.command_settings
+        current = getattr(cs, field)
+        raw = await ctx.prompt(
+            label,
+            preamble_lines=[
+                f'Current: {current or "(none)"}  '
+                f'(name, - to clear, {ctx.player.return_key} to cancel)'
+            ],
+        )
+        if raw is None or not raw.strip():
+            return
+        text = raw.strip()
+        if text == '-':
+            setattr(cs, field, None)
+            p.unsaved_changes = True
+            await ctx.send(f'{label}: (none)')
+            return
+        if not player_exists(ctx.server, text):
+            await ctx.send(f'No such player "{text}".')
+            return
+        # Prefer the canonical stored casing if we can find it.
+        matches = find_players(ctx.server, text)
+        name    = next((m for m in matches if m.lower() == text.lower()), text)
+        setattr(cs, field, name)
+        p.unsaved_changes = True
+        await ctx.send(f'{label}: {name}')
+
+    menu.add_item(MenuItem(
+        'Last Paged', shortcuts='lp',
+        dot_leader_handler=lambda ctx: p.command_settings.last_paged or '(none)',
+        action=lambda ctx: _edit_reply_target(ctx, 'last_paged', 'Last Paged'),
+    ))
+    menu.add_item(MenuItem(
+        'Last Whispered', shortcuts='lw',
+        dot_leader_handler=lambda ctx: p.command_settings.last_whispered or '(none)',
+        action=lambda ctx: _edit_reply_target(ctx, 'last_whispered', 'Last Whispered'),
+    ))
     return menu
 
 

--- a/server/commands/editplayer.py
+++ b/server/commands/editplayer.py
@@ -761,16 +761,15 @@ def _command_settings_menu(ctx) -> Menu:
         action=edit_news_last_read,
     ))
 
-    # last_paged / last_whispered: the target for the '#reply' / '#r' token
-    # in commands/page.py and commands/whisper.py -- normally maintained by
-    # those commands themselves (set on both send and receive). Editable
-    # here so an admin can point a player's reply target at someone else or
-    # clear a stale one.
-    async def _edit_reply_target(ctx, field: str, label: str) -> None:
+    # command_settings.page.* / command_settings.whisper.*: the '#reply'
+    # target and the '#last' history/limit, normally maintained by
+    # commands/page.py and commands/whisper.py themselves. Exposed here so
+    # an admin can repoint or clear a stale reply target, wipe a history,
+    # or tune the show limit.
+    async def _edit_reply_target(ctx, ns, field: str, label: str) -> None:
         from tada_utilities import find_players, player_exists
 
-        cs      = p.command_settings
-        current = getattr(cs, field)
+        current = getattr(ns, field)
         raw = await ctx.prompt(
             label,
             preamble_lines=[
@@ -782,7 +781,7 @@ def _command_settings_menu(ctx) -> Menu:
             return
         text = raw.strip()
         if text == '-':
-            setattr(cs, field, None)
+            setattr(ns, field, None)
             p.unsaved_changes = True
             await ctx.send(f'{label}: (none)')
             return
@@ -792,19 +791,68 @@ def _command_settings_menu(ctx) -> Menu:
         # Prefer the canonical stored casing if we can find it.
         matches = find_players(ctx.server, text)
         name    = next((m for m in matches if m.lower() == text.lower()), text)
-        setattr(cs, field, name)
+        setattr(ns, field, name)
         p.unsaved_changes = True
         await ctx.send(f'{label}: {name}')
 
+    async def _edit_last_limit(ctx, ns, label: str) -> None:
+        val = await _prompt_int(ctx, label, ns.last_limit, 1, 10)
+        if val is None:
+            return
+        ns.last_limit = val
+        p.unsaved_changes = True
+        await ctx.send(f'{label}: {val}')
+
+    async def _view_clear_history(ctx, ns, label: str, verb: str) -> None:
+        from commands.messaging import render_last_history
+
+        if not ns.history:
+            await ctx.send(f'{label}: (empty)')
+            return
+        await ctx.send(render_last_history(ns.history, len(ns.history), verb=verb))
+        raw = await ctx.prompt(
+            'Clear it?',
+            preamble_lines=[f'y to clear, {ctx.player.return_key} to keep'])
+        if raw and raw.strip().lower().startswith('y'):
+            ns.history.clear()
+            p.unsaved_changes = True
+            await ctx.send(f'{label}: cleared.')
+
     menu.add_item(MenuItem(
         'Last Paged', shortcuts='lp',
-        dot_leader_handler=lambda ctx: p.command_settings.last_paged or '(none)',
-        action=lambda ctx: _edit_reply_target(ctx, 'last_paged', 'Last Paged'),
+        dot_leader_handler=lambda ctx: p.command_settings.page.last_paged or '(none)',
+        action=lambda ctx: _edit_reply_target(
+            ctx, p.command_settings.page, 'last_paged', 'Last Paged'),
     ))
     menu.add_item(MenuItem(
         'Last Whispered', shortcuts='lw',
-        dot_leader_handler=lambda ctx: p.command_settings.last_whispered or '(none)',
-        action=lambda ctx: _edit_reply_target(ctx, 'last_whispered', 'Last Whispered'),
+        dot_leader_handler=lambda ctx: p.command_settings.whisper.last_whispered or '(none)',
+        action=lambda ctx: _edit_reply_target(
+            ctx, p.command_settings.whisper, 'last_whispered', 'Last Whispered'),
+    ))
+    menu.add_item(MenuItem(
+        'Page #last Limit', shortcuts='pl',
+        dot_leader_handler=lambda ctx: str(p.command_settings.page.last_limit),
+        action=lambda ctx: _edit_last_limit(
+            ctx, p.command_settings.page, 'Page #last Limit'),
+    ))
+    menu.add_item(MenuItem(
+        'Whisper #last Limit', shortcuts='wl',
+        dot_leader_handler=lambda ctx: str(p.command_settings.whisper.last_limit),
+        action=lambda ctx: _edit_last_limit(
+            ctx, p.command_settings.whisper, 'Whisper #last Limit'),
+    ))
+    menu.add_item(MenuItem(
+        'Page History', shortcuts='ph',
+        dot_leader_handler=lambda ctx: f'{len(p.command_settings.page.history)} entries',
+        action=lambda ctx: _view_clear_history(
+            ctx, p.command_settings.page, 'Page History', 'paged'),
+    ))
+    menu.add_item(MenuItem(
+        'Whisper History', shortcuts='wht',
+        dot_leader_handler=lambda ctx: f'{len(p.command_settings.whisper.history)} entries',
+        action=lambda ctx: _view_clear_history(
+            ctx, p.command_settings.whisper, 'Whisper History', 'whispered'),
     ))
     return menu
 

--- a/server/commands/messaging.py
+++ b/server/commands/messaging.py
@@ -36,6 +36,29 @@ def parse_targets(targets_str: str) -> list[str]:
     return [t for t in tokens if t]
 
 
+# '#reply' / '#r' target tokens (commands/page.py, commands/whisper.py):
+# stand in for "whoever I last exchanged this kind of message with" so you
+# don't retype the name. Resolved by substitute_reply() *before*
+# expand_groups(), so they always win over a same-named saved group (same
+# as page.py's #ignore/#haven control words shadowing group names).
+REPLY_TOKENS = {'#reply', '#r'}
+
+
+def substitute_reply(targets: list[str],
+                     last_name: 'str | None') -> tuple[list[str], bool]:
+    """Replace any '#reply' / '#r' token in *targets* with *last_name*.
+
+    Returns (new_targets, unresolved).  *unresolved* is True when a reply
+    token was present but *last_name* is None -- the caller should report
+    "no one to reply to" and stop rather than send anything.
+    """
+    if not any(t.lower() in REPLY_TOKENS for t in targets):
+        return targets, False
+    if not last_name:
+        return targets, True
+    return [last_name if t.lower() in REPLY_TOKENS else t for t in targets], False
+
+
 def expand_groups(player, targets: list[str]) -> tuple[list[str], list[str]]:
     """Replace #groupname tokens with the player's stored member lists.
 

--- a/server/commands/messaging.py
+++ b/server/commands/messaging.py
@@ -13,6 +13,7 @@ messaging (bar/, commands/board/edit.py). Re-imported here just for
 prompt_player_choice()'s own use below.
 """
 import shlex
+from datetime import datetime
 
 from tada_utilities import find_players, online_player_names
 
@@ -57,6 +58,81 @@ def substitute_reply(targets: list[str],
     if not last_name:
         return targets, True
     return [last_name if t.lower() in REPLY_TOKENS else t for t in targets], False
+
+
+# --- 'page #last' / 'whisper #last' recent-recipient history ---------------
+# Each command keeps a per-channel ring buffer of who you last messaged in
+# command_settings.page.history / command_settings.whisper.history: a list
+# of {'name': str, 'at': isoformat-str} dicts, most-recent-first,
+# de-duplicated by name (case-insensitively), capped at LAST_HISTORY_CAP.
+# 'page #last' / 'whisper #last' render it; 'page #last N' sets how many
+# lines to show (command_settings.page.last_limit / whisper.last_limit,
+# 1..LAST_LIMIT_MAX).
+LAST_HISTORY_CAP   = 10
+LAST_LIMIT_MAX     = 10
+LAST_LIMIT_DEFAULT = 5
+
+
+def record_message_target(history: list, name: str) -> None:
+    """Push *name* onto a '#last' history ring buffer, mutating it in place.
+
+    Newest first; an earlier entry for the same name (case-insensitive) is
+    dropped so the list stays one-per-person; trimmed to LAST_HISTORY_CAP.
+    """
+    key = name.lower()
+    history[:] = [e for e in history
+                  if str(e.get('name', '')).lower() != key]
+    history.insert(0, {'name': name, 'at': datetime.now().isoformat()})
+    del history[LAST_HISTORY_CAP:]
+
+
+def _relative_age(iso: str) -> str:
+    """'just now' / '5m ago' / '3h ago' / '2d ago' for an isoformat string."""
+    try:
+        then = datetime.fromisoformat(str(iso))
+    except (TypeError, ValueError):
+        return '?'
+    if then.tzinfo is not None:
+        then = then.replace(tzinfo=None)
+    secs = (datetime.now() - then).total_seconds()
+    if secs < 45:
+        return 'just now'
+    if secs < 2700:        # 45 minutes
+        return f'{round(secs / 60)}m ago'
+    if secs < 79200:       # 22 hours
+        return f'{round(secs / 3600)}h ago'
+    return f'{round(secs / 86400)}d ago'
+
+
+def render_last_history(history: list, limit: int, *, verb: str) -> list[str]:
+    """Lines for 'page #last' / 'whisper #last'.  *verb* is 'paged'/'whispered'."""
+    if not history:
+        return [f'You have not {verb} anyone yet.']
+    shown = history[:max(1, limit)]
+    head  = (f'Last person you {verb}' if len(shown) == 1
+             else f'Last {len(shown)} people you {verb}')
+    return [head + ':'] + [
+        f'  {e.get("name", "?")}  ({_relative_age(e.get("at"))})' for e in shown
+    ]
+
+
+def parse_last_limit(rest) -> 'tuple[int | None, str | None]':
+    """Interpret the tokens after '#last'.
+
+    Returns (new_limit, error):
+      (None, None) -- no number given, caller should just display
+      (N,    None) -- caller should set the show-limit to N
+      (None, msg)  -- invalid input, caller should report msg
+    """
+    if not rest:
+        return None, None
+    tok = str(rest[0]).strip()
+    if not tok.isdigit():
+        return None, f'Usage: #last [1-{LAST_LIMIT_MAX}]'
+    n = int(tok)
+    if not 1 <= n <= LAST_LIMIT_MAX:
+        return None, f'Pick a number from 1 to {LAST_LIMIT_MAX}.'
+    return n, None
 
 
 def expand_groups(player, targets: list[str]) -> tuple[list[str], list[str]]:

--- a/server/commands/page.py
+++ b/server/commands/page.py
@@ -9,6 +9,12 @@ Syntax:
   page #unignore <name>      remove that block
   page #haven                block ALL incoming pages
   page #unhaven               allow pages again
+  page #reply=<message>      page whoever you last paged with
+  page #r=<message>          short form of #reply
+
+#reply/#r stand in for your last page correspondent (set both when you
+send a page and when you receive one -- CommandSettings.last_paged), so
+you can answer without retyping the name.
 
 #ignore/#unignore/#haven/#unhaven are reserved control words, so a saved
 group cannot be named "ignore", "unignore", "haven", or "unhaven".
@@ -22,6 +28,7 @@ Examples:
     page Alice,Bob=Party at the inn
     page "Dark Lord"=Surrender now
     page #friends=Where is everyone?
+    page #r=on my way
     page #ignore Bob
     page #haven
 """
@@ -30,7 +37,9 @@ from __future__ import annotations
 import mail as mail_store
 from commands.base_command import Command, CommandResult, Mode
 from commands.help import Help, HelpCategory
-from commands.messaging import parse_targets, expand_groups, find_online, is_in_combat
+from commands.messaging import (
+    parse_targets, expand_groups, find_online, is_in_combat, substitute_reply,
+)
 from network_context import GameContext
 from tada_utilities import player_exists
 
@@ -49,6 +58,7 @@ class PageCommand(Command):
             ('page <name>=<message>',           'Page one player'),
             ('page <name>,<name2>=<message>',   'Page multiple players'),
             ('page #<group>=<message>',         'Page everyone in a group'),
+            ('page #r=<message>',               'Page back to your last correspondent'),
             ('page #ignore <name>',             'Block <name> from paging you'),
             ('page #unignore <name>',           'Remove that block'),
             ('page #haven',                     'Block all incoming pages'),
@@ -65,6 +75,10 @@ class PageCommand(Command):
             ('page #friends=Where is everyone?','A saved GROUPS name (see GROUPS) works '
                                                  "as a target too, paging everyone in it "
                                                  'without listing them by name.'),
+            ('page #r=on my way',              "'#reply' (or '#r') stands in for the "
+                                                 'last player you paged with -- either '
+                                                 'direction -- so you can answer a page '
+                                                 "without retyping their name."),
             ('p Bob=Meet me at the inn',        "'p' (also 'tell'/'msg') is a shorter "
                                                  'alias for page -- all work the same '
                                                  'way.'),
@@ -157,6 +171,13 @@ class PageCommand(Command):
             await ctx.send('Page whom?  Usage: page <name[[,name2]]>=<message>')
             return CommandResult.fail('Missing target name.')
 
+        # '#reply' / '#r' -> whoever you last paged with
+        target_names, unresolved_reply = substitute_reply(
+            target_names, ctx.player.command_settings.last_paged)
+        if unresolved_reply:
+            await ctx.send("You haven't paged anyone yet.")
+            return CommandResult.fail('No one to reply to.')
+
         my_name = ctx.player.name
 
         # Remove self from target list silently
@@ -212,10 +233,18 @@ class PageCommand(Command):
                 queued_names.append(tctx.player.name)
             else:
                 await tctx.send(f'{my_name} pages you, "{message}"')
+            # Recipient's '#reply' now points back at the sender (the
+            # queued case still delivers, just later).
+            tctx.player.command_settings.last_paged = my_name
+            tctx.player.unsaved_changes = True
 
         if queued_names:
             await ctx.send(f'({", ".join(queued_names)} {"is" if len(queued_names) == 1 else "are"} '
                             f'in combat -- your page will show up for them after.)')
+
+        # Sender's '#reply' points at the last person actually reached.
+        ctx.player.command_settings.last_paged = deliverable[-1].player.name
+        ctx.player.unsaved_changes = True
 
         return CommandResult.ok()
 

--- a/server/commands/page.py
+++ b/server/commands/page.py
@@ -11,13 +11,18 @@ Syntax:
   page #unhaven               allow pages again
   page #reply=<message>      page whoever you last paged with
   page #r=<message>          short form of #reply
+  page #last [N]             list the last people you paged; #last N
+                              (1-10) also sets how many to show
 
 #reply/#r stand in for your last page correspondent (set both when you
-send a page and when you receive one -- CommandSettings.last_paged), so
-you can answer without retyping the name.
+send a page and when you receive one -- command_settings.page.last_paged),
+so you can answer without retyping the name.  #last reads back a running
+history of who you've paged (command_settings.page.history), newest first,
+with a relative timestamp on each.
 
-#ignore/#unignore/#haven/#unhaven are reserved control words, so a saved
-group cannot be named "ignore", "unignore", "haven", or "unhaven".
+#ignore/#unignore/#haven/#unhaven/#last are reserved control words, so a
+saved group cannot be named "ignore", "unignore", "haven", "unhaven", or
+"last".
 
 If a target isn't currently online, offers to leave the message as mail
 for them (mail.py's add_message() -- read back via the `mail` command,
@@ -29,6 +34,8 @@ Examples:
     page "Dark Lord"=Surrender now
     page #friends=Where is everyone?
     page #r=on my way
+    page #last
+    page #last 5
     page #ignore Bob
     page #haven
 """
@@ -39,11 +46,12 @@ from commands.base_command import Command, CommandResult, Mode
 from commands.help import Help, HelpCategory
 from commands.messaging import (
     parse_targets, expand_groups, find_online, is_in_combat, substitute_reply,
+    record_message_target, render_last_history, parse_last_limit,
 )
 from network_context import GameContext
 from tada_utilities import player_exists
 
-_CONTROL_WORDS = {'#ignore', '#unignore', '#haven', '#unhaven'}
+_CONTROL_WORDS = {'#ignore', '#unignore', '#haven', '#unhaven', '#last'}
 
 
 class PageCommand(Command):
@@ -59,6 +67,7 @@ class PageCommand(Command):
             ('page <name>,<name2>=<message>',   'Page multiple players'),
             ('page #<group>=<message>',         'Page everyone in a group'),
             ('page #r=<message>',               'Page back to your last correspondent'),
+            ('page #last [N]',                  'List the last people you paged (N: how many, 1-10)'),
             ('page #ignore <name>',             'Block <name> from paging you'),
             ('page #unignore <name>',           'Remove that block'),
             ('page #haven',                     'Block all incoming pages'),
@@ -79,6 +88,10 @@ class PageCommand(Command):
                                                  'last player you paged with -- either '
                                                  'direction -- so you can answer a page '
                                                  "without retyping their name."),
+            ('page #last 5',                   "'#last' lists who you've paged recently, "
+                                                 'newest first, with how long ago.  '
+                                                 "'#last 5' also saves 5 as the number "
+                                                 'of entries to show (1-10).'),
             ('p Bob=Meet me at the inn',        "'p' (also 'tell'/'msg') is a shorter "
                                                  'alias for page -- all work the same '
                                                  'way.'),
@@ -112,7 +125,7 @@ class PageCommand(Command):
     # ------------------------------------------------------------------
 
     async def _control(self, ctx: GameContext, word: str, rest: tuple) -> CommandResult:
-        cs = ctx.player.command_settings
+        cs = ctx.player.command_settings.page
 
         if word == '#haven':
             cs.haven = True
@@ -125,6 +138,19 @@ class PageCommand(Command):
             ctx.player.unsaved_changes = True
             await ctx.send('You can receive pages again.')
             return CommandResult.ok('Haven off.')
+
+        if word == '#last':
+            new_limit, err = parse_last_limit(rest)
+            if err:
+                await ctx.send(err)
+                return CommandResult.fail(err, error='bad_args')
+            if new_limit is not None and new_limit != cs.last_limit:
+                cs.last_limit = new_limit
+                ctx.player.unsaved_changes = True
+                await ctx.send(f'page #last now shows up to {new_limit}.')
+            await ctx.send(render_last_history(
+                cs.history, cs.last_limit, verb='paged'))
+            return CommandResult.ok('Shown.')
 
         if not rest:
             await ctx.send(f'Usage: page {word} <name>')
@@ -173,7 +199,7 @@ class PageCommand(Command):
 
         # '#reply' / '#r' -> whoever you last paged with
         target_names, unresolved_reply = substitute_reply(
-            target_names, ctx.player.command_settings.last_paged)
+            target_names, ctx.player.command_settings.page.last_paged)
         if unresolved_reply:
             await ctx.send("You haven't paged anyone yet.")
             return CommandResult.fail('No one to reply to.')
@@ -199,8 +225,9 @@ class PageCommand(Command):
         deliverable = []
         for tctx in found_ctxs:
             tcs     = getattr(tctx.player, 'command_settings', None)
-            haven   = getattr(tcs, 'haven', False) if tcs else False
-            ignored = getattr(tcs, 'ignored_pagers', []) if tcs else []
+            tpage   = getattr(tcs, 'page', None) if tcs else None
+            haven   = getattr(tpage, 'haven', False) if tpage else False
+            ignored = getattr(tpage, 'ignored_pagers', []) if tpage else []
             if haven:
                 await ctx.send(f'{tctx.player.name} is not accepting pages right now.')
                 continue
@@ -235,15 +262,18 @@ class PageCommand(Command):
                 await tctx.send(f'{my_name} pages you, "{message}"')
             # Recipient's '#reply' now points back at the sender (the
             # queued case still delivers, just later).
-            tctx.player.command_settings.last_paged = my_name
+            tctx.player.command_settings.page.last_paged = my_name
             tctx.player.unsaved_changes = True
+            # ...and this recipient joins the sender's 'page #last' history.
+            record_message_target(
+                ctx.player.command_settings.page.history, tctx.player.name)
 
         if queued_names:
             await ctx.send(f'({", ".join(queued_names)} {"is" if len(queued_names) == 1 else "are"} '
                             f'in combat -- your page will show up for them after.)')
 
         # Sender's '#reply' points at the last person actually reached.
-        ctx.player.command_settings.last_paged = deliverable[-1].player.name
+        ctx.player.command_settings.page.last_paged = deliverable[-1].player.name
         ctx.player.unsaved_changes = True
 
         return CommandResult.ok()

--- a/server/commands/whisper.py
+++ b/server/commands/whisper.py
@@ -4,15 +4,22 @@ Syntax:  whisper <targets>=<message>
 Targets: a comma- or space-delimited list of names; quote names that contain
          spaces; use #groupname to address everyone in a saved group.
 
+Use #reply (or #r) as the target to whisper back to whoever you last
+whispered with, without retyping their name -- the last correspondent is
+remembered in CommandSettings.last_whispered.
+
 Examples:
     whisper Bob=Did you see that?
     whisper Alice,Bob=Let's sneak out
     whisper "Dark Lord"=I come in peace
     whisper #friends=Meet at the inn
+    whisper #r=me too
 """
 from commands.base_command import Command, CommandResult, Mode
 from commands.help import Help, HelpCategory
-from commands.messaging import parse_targets, expand_groups, find_online
+from commands.messaging import (
+    parse_targets, expand_groups, find_online, substitute_reply,
+)
 from network_context import GameContext
 
 
@@ -29,6 +36,7 @@ class WhisperCommand(Command):
             ('whisper <name>=<message>',           'Whisper to one player'),
             ('whisper <name>,<name2>=<message>',   'Whisper to multiple players'),
             ('whisper #<group>=<message>',         'Whisper to everyone in a group'),
+            ('whisper #r=<message>',               'Whisper back to your last correspondent'),
         ],
         examples = [
             ('whisper Bob=Did you see that?',      "WHISPER sends a message only the "
@@ -46,6 +54,10 @@ class WhisperCommand(Command):
                                                     'target too, whispering to everyone '
                                                     'in it who happens to be in the room '
                                                     'with you.'),
+            ('whisper #r=me too',                  "'#reply' (or '#r') stands in for the "
+                                                    'last player you whispered with -- '
+                                                    'either direction -- so you can '
+                                                    "answer without retyping their name."),
         ],
         notes = ['Target must be in the same room.  Use [page] for cross-room messages.'],
     )
@@ -75,6 +87,13 @@ class WhisperCommand(Command):
             await ctx.send('Whisper to whom?  Usage: whisper <name[[,name2]]>=<message>')
             return CommandResult.fail('Missing target name.')
 
+        # '#reply' / '#r' -> whoever you last whispered with
+        target_names, unresolved_reply = substitute_reply(
+            target_names, ctx.player.command_settings.last_whispered)
+        if unresolved_reply:
+            await ctx.send("You haven't whispered with anyone yet.")
+            return CommandResult.fail('No one to reply to.')
+
         my_name = ctx.player.name
 
         # Remove self from target list silently
@@ -102,5 +121,12 @@ class WhisperCommand(Command):
         await ctx.send(f'You whisper to {names_str}, "{message}"')
         for tctx in found_ctxs:
             await tctx.send(f'{my_name} whispers to you, "{message}"')
+            # Recipient's '#reply' now points back at the sender.
+            tctx.player.command_settings.last_whispered = my_name
+            tctx.player.unsaved_changes = True
+
+        # Sender's '#reply' points at the last person actually reached.
+        ctx.player.command_settings.last_whispered = found_ctxs[-1].player.name
+        ctx.player.unsaved_changes = True
 
         return CommandResult.ok()

--- a/server/commands/whisper.py
+++ b/server/commands/whisper.py
@@ -6,7 +6,11 @@ Targets: a comma- or space-delimited list of names; quote names that contain
 
 Use #reply (or #r) as the target to whisper back to whoever you last
 whispered with, without retyping their name -- the last correspondent is
-remembered in CommandSettings.last_whispered.
+remembered in command_settings.whisper.last_whispered.
+
+"whisper #last [N]" lists the last people you whispered to (newest first,
+each with a relative timestamp, from command_settings.whisper.history);
+"whisper #last N" also saves N (1-10) as how many entries to show.
 
 Examples:
     whisper Bob=Did you see that?
@@ -14,11 +18,14 @@ Examples:
     whisper "Dark Lord"=I come in peace
     whisper #friends=Meet at the inn
     whisper #r=me too
+    whisper #last
+    whisper #last 5
 """
 from commands.base_command import Command, CommandResult, Mode
 from commands.help import Help, HelpCategory
 from commands.messaging import (
     parse_targets, expand_groups, find_online, substitute_reply,
+    record_message_target, render_last_history, parse_last_limit,
 )
 from network_context import GameContext
 
@@ -37,6 +44,7 @@ class WhisperCommand(Command):
             ('whisper <name>,<name2>=<message>',   'Whisper to multiple players'),
             ('whisper #<group>=<message>',         'Whisper to everyone in a group'),
             ('whisper #r=<message>',               'Whisper back to your last correspondent'),
+            ('whisper #last [N]',                  'List the last people you whispered to (N: how many, 1-10)'),
         ],
         examples = [
             ('whisper Bob=Did you see that?',      "WHISPER sends a message only the "
@@ -58,6 +66,10 @@ class WhisperCommand(Command):
                                                     'last player you whispered with -- '
                                                     'either direction -- so you can '
                                                     "answer without retyping their name."),
+            ('whisper #last 5',                    "'#last' lists who you've whispered to "
+                                                    'recently, newest first, with how '
+                                                    "long ago.  '#last 5' also saves 5 as "
+                                                    'the number of entries to show (1-10).'),
         ],
         notes = ['Target must be in the same room.  Use [page] for cross-room messages.'],
     )
@@ -68,6 +80,22 @@ class WhisperCommand(Command):
         if not args:
             await ctx.send('Whisper to whom?  Usage: whisper <name[[,name2]]>=<message>')
             return CommandResult.fail('No arguments.')
+
+        # 'whisper #last [N]' -- list recent recipients / set the show limit.
+        # Handled before the '=' check since it has no message part.
+        if args[0].lower() == '#last':
+            cs = ctx.player.command_settings.whisper
+            new_limit, err = parse_last_limit(args[1:])
+            if err:
+                await ctx.send(err)
+                return CommandResult.fail(err, error='bad_args')
+            if new_limit is not None and new_limit != cs.last_limit:
+                cs.last_limit = new_limit
+                ctx.player.unsaved_changes = True
+                await ctx.send(f'whisper #last now shows up to {new_limit}.')
+            await ctx.send(render_last_history(
+                cs.history, cs.last_limit, verb='whispered'))
+            return CommandResult.ok('Shown.')
 
         raw = ' '.join(args)
 
@@ -89,7 +117,7 @@ class WhisperCommand(Command):
 
         # '#reply' / '#r' -> whoever you last whispered with
         target_names, unresolved_reply = substitute_reply(
-            target_names, ctx.player.command_settings.last_whispered)
+            target_names, ctx.player.command_settings.whisper.last_whispered)
         if unresolved_reply:
             await ctx.send("You haven't whispered with anyone yet.")
             return CommandResult.fail('No one to reply to.')
@@ -122,11 +150,14 @@ class WhisperCommand(Command):
         for tctx in found_ctxs:
             await tctx.send(f'{my_name} whispers to you, "{message}"')
             # Recipient's '#reply' now points back at the sender.
-            tctx.player.command_settings.last_whispered = my_name
+            tctx.player.command_settings.whisper.last_whispered = my_name
             tctx.player.unsaved_changes = True
+            # ...and joins the sender's 'whisper #last' history.
+            record_message_target(
+                ctx.player.command_settings.whisper.history, tctx.player.name)
 
         # Sender's '#reply' points at the last person actually reached.
-        ctx.player.command_settings.last_whispered = found_ctxs[-1].player.name
+        ctx.player.command_settings.whisper.last_whispered = found_ctxs[-1].player.name
         ctx.player.unsaved_changes = True
 
         return CommandResult.ok()

--- a/server/tests/admin/test_editplayer.py
+++ b/server/tests/admin/test_editplayer.py
@@ -525,21 +525,21 @@ class TestCommandSettingsReplyTargetMenu(unittest.IsolatedAsyncioTestCase):
 
     async def test_dot_leader_shows_name_when_set(self):
         ctx = self._ctx()
-        ctx.player.command_settings.last_paged = 'Alice'
+        ctx.player.command_settings.page.last_paged = 'Alice'
         self.assertEqual(self._item(ctx, 'Last Paged').dot_leader_handler(ctx), 'Alice')
 
     async def test_blank_leaves_unchanged(self):
         ctx = self._ctx(responses=[''])
-        ctx.player.command_settings.last_paged = 'Alice'
+        ctx.player.command_settings.page.last_paged = 'Alice'
         await self._item(ctx, 'Last Paged').action(ctx)
-        self.assertEqual(ctx.player.command_settings.last_paged, 'Alice')
+        self.assertEqual(ctx.player.command_settings.page.last_paged, 'Alice')
         self.assertFalse(ctx.player.unsaved_changes)
 
     async def test_dash_clears(self):
         ctx = self._ctx(responses=['-'])
-        ctx.player.command_settings.last_whispered = 'Bob'
+        ctx.player.command_settings.whisper.last_whispered = 'Bob'
         await self._item(ctx, 'Last Whispered').action(ctx)
-        self.assertIsNone(ctx.player.command_settings.last_whispered)
+        self.assertIsNone(ctx.player.command_settings.whisper.last_whispered)
         self.assertTrue(ctx.player.unsaved_changes)
 
     async def test_sets_to_existing_player_canonical_casing(self):
@@ -547,16 +547,68 @@ class TestCommandSettingsReplyTargetMenu(unittest.IsolatedAsyncioTestCase):
         with unittest.mock.patch('tada_utilities.player_exists', return_value=True), \
              unittest.mock.patch('tada_utilities.find_players', return_value=['Alice']):
             await self._item(ctx, 'Last Paged').action(ctx)
-        self.assertEqual(ctx.player.command_settings.last_paged, 'Alice')
+        self.assertEqual(ctx.player.command_settings.page.last_paged, 'Alice')
         self.assertTrue(ctx.player.unsaved_changes)
 
     async def test_unknown_player_rejected(self):
         ctx = self._ctx(responses=['Nobody'])
         with unittest.mock.patch('tada_utilities.player_exists', return_value=False):
             await self._item(ctx, 'Last Paged').action(ctx)
-        self.assertIsNone(ctx.player.command_settings.last_paged)
+        self.assertIsNone(ctx.player.command_settings.page.last_paged)
         self.assertFalse(ctx.player.unsaved_changes)
         self.assertIn('No such player "Nobody".', ctx.sent)
+
+
+class TestCommandSettingsLastHistoryMenu(unittest.IsolatedAsyncioTestCase):
+    """'Page/Whisper #last Limit' and 'Page/Whisper History' entries."""
+
+    def _item(self, ctx, text):
+        menu = _command_settings_menu(ctx)
+        return next(i for i in menu.selectable if i.text == text)
+
+    async def test_limit_dot_leader_reflects_value(self):
+        ctx = _MockCtx()
+        item = self._item(ctx, 'Page #last Limit')
+        self.assertEqual(item.dot_leader_handler(ctx), '5')
+        ctx.player.command_settings.page.last_limit = 8
+        self.assertEqual(item.dot_leader_handler(ctx), '8')
+
+    async def test_limit_edit_sets_and_marks_unsaved(self):
+        ctx = _MockCtx(responses=['3'])
+        await self._item(ctx, 'Page #last Limit').action(ctx)
+        self.assertEqual(ctx.player.command_settings.page.last_limit, 3)
+        self.assertTrue(ctx.player.unsaved_changes)
+
+    async def test_limit_edit_out_of_range_keeps_prompting_then_cancels(self):
+        # 99 rejected, then blank cancels -> unchanged
+        ctx = _MockCtx(responses=['99', ''])
+        await self._item(ctx, 'Whisper #last Limit').action(ctx)
+        self.assertEqual(ctx.player.command_settings.whisper.last_limit, 5)
+
+    async def test_history_dot_leader_shows_count(self):
+        ctx = _MockCtx()
+        ctx.player.command_settings.page.history = [
+            {'name': 'Alice', 'at': 'x'}, {'name': 'Bob', 'at': 'x'}]
+        self.assertEqual(
+            self._item(ctx, 'Page History').dot_leader_handler(ctx), '2 entries')
+
+    async def test_history_empty_reports_and_no_prompt(self):
+        ctx = _MockCtx()
+        await self._item(ctx, 'Page History').action(ctx)
+        self.assertIn('Page History: (empty)', ctx.sent)
+
+    async def test_history_clear_on_yes(self):
+        ctx = _MockCtx(responses=['y'])
+        ctx.player.command_settings.whisper.history = [{'name': 'Alice', 'at': 'x'}]
+        await self._item(ctx, 'Whisper History').action(ctx)
+        self.assertEqual(ctx.player.command_settings.whisper.history, [])
+        self.assertTrue(ctx.player.unsaved_changes)
+
+    async def test_history_kept_on_blank(self):
+        ctx = _MockCtx(responses=[''])
+        ctx.player.command_settings.page.history = [{'name': 'Alice', 'at': 'x'}]
+        await self._item(ctx, 'Page History').action(ctx)
+        self.assertEqual(len(ctx.player.command_settings.page.history), 1)
 
 
 # ---------------------------------------------------------------------------

--- a/server/tests/admin/test_editplayer.py
+++ b/server/tests/admin/test_editplayer.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import asyncio
 import sys
 import unittest
+import unittest.mock
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -501,6 +502,61 @@ class TestCommandSettingsNewsMenu(unittest.IsolatedAsyncioTestCase):
         await item.action(ctx)
         self.assertEqual(ctx.player.command_settings.news.last_read, '2026-08-19T00:00:00')
         self.assertIn("Didn't understand that date.", ctx.sent)
+
+
+class TestCommandSettingsReplyTargetMenu(unittest.IsolatedAsyncioTestCase):
+    """'Last Paged' / 'Last Whispered' entries -- the '#reply'/'#r' target
+    for commands/page.py and commands/whisper.py, editable by an admin."""
+
+    def _item(self, ctx, text):
+        menu = _command_settings_menu(ctx)
+        return next(i for i in menu.selectable if i.text == text)
+
+    def _ctx(self, responses=None):
+        import types
+        ctx = _MockCtx(responses=responses)
+        ctx.server = types.SimpleNamespace(clients={})
+        return ctx
+
+    async def test_dot_leader_shows_none_when_unset(self):
+        ctx = self._ctx()
+        self.assertEqual(self._item(ctx, 'Last Paged').dot_leader_handler(ctx), '(none)')
+        self.assertEqual(self._item(ctx, 'Last Whispered').dot_leader_handler(ctx), '(none)')
+
+    async def test_dot_leader_shows_name_when_set(self):
+        ctx = self._ctx()
+        ctx.player.command_settings.last_paged = 'Alice'
+        self.assertEqual(self._item(ctx, 'Last Paged').dot_leader_handler(ctx), 'Alice')
+
+    async def test_blank_leaves_unchanged(self):
+        ctx = self._ctx(responses=[''])
+        ctx.player.command_settings.last_paged = 'Alice'
+        await self._item(ctx, 'Last Paged').action(ctx)
+        self.assertEqual(ctx.player.command_settings.last_paged, 'Alice')
+        self.assertFalse(ctx.player.unsaved_changes)
+
+    async def test_dash_clears(self):
+        ctx = self._ctx(responses=['-'])
+        ctx.player.command_settings.last_whispered = 'Bob'
+        await self._item(ctx, 'Last Whispered').action(ctx)
+        self.assertIsNone(ctx.player.command_settings.last_whispered)
+        self.assertTrue(ctx.player.unsaved_changes)
+
+    async def test_sets_to_existing_player_canonical_casing(self):
+        ctx = self._ctx(responses=['alice'])
+        with unittest.mock.patch('tada_utilities.player_exists', return_value=True), \
+             unittest.mock.patch('tada_utilities.find_players', return_value=['Alice']):
+            await self._item(ctx, 'Last Paged').action(ctx)
+        self.assertEqual(ctx.player.command_settings.last_paged, 'Alice')
+        self.assertTrue(ctx.player.unsaved_changes)
+
+    async def test_unknown_player_rejected(self):
+        ctx = self._ctx(responses=['Nobody'])
+        with unittest.mock.patch('tada_utilities.player_exists', return_value=False):
+            await self._item(ctx, 'Last Paged').action(ctx)
+        self.assertIsNone(ctx.player.command_settings.last_paged)
+        self.assertFalse(ctx.player.unsaved_changes)
+        self.assertIn('No such player "Nobody".', ctx.sent)
 
 
 # ---------------------------------------------------------------------------

--- a/server/tests/social/test_mail_command.py
+++ b/server/tests/social/test_mail_command.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import mail as mail_store
+from command_settings import PageSettings, WhisperSettings
 from commands.mail import MailCommand
 from flags import PlayerFlags
 
@@ -22,9 +23,10 @@ def run(coro):
 class _FakeCommandSettings:
     def __init__(self, groups=None):
         self.groups = groups or {}
-        # PageCommand records the last correspondent for '#reply'/'#r'
-        self.last_paged = None
-        self.last_whispered = None
+        # PageCommand / WhisperCommand touch command_settings.page.* /
+        # command_settings.whisper.* (#reply target + #last history).
+        self.page = PageSettings()
+        self.whisper = WhisperSettings()
 
 
 class _FakePlayer:

--- a/server/tests/social/test_mail_command.py
+++ b/server/tests/social/test_mail_command.py
@@ -22,6 +22,9 @@ def run(coro):
 class _FakeCommandSettings:
     def __init__(self, groups=None):
         self.groups = groups or {}
+        # PageCommand records the last correspondent for '#reply'/'#r'
+        self.last_paged = None
+        self.last_whispered = None
 
 
 class _FakePlayer:

--- a/server/tests/social/test_messaging.py
+++ b/server/tests/social/test_messaging.py
@@ -21,6 +21,8 @@ from command_settings import CommandSettings
 from commands.messaging import (
     parse_targets, expand_groups, find_online,
     prompt_player_choice, substitute_reply,
+    record_message_target, render_last_history, parse_last_limit,
+    _relative_age, LAST_HISTORY_CAP, LAST_LIMIT_MAX,
 )
 from tada_utilities import online_player_names, is_online, player_exists, find_players
 from commands.groups import GroupsCommand
@@ -827,7 +829,7 @@ class TestPageControlWords(unittest.TestCase):
         ctx, server = _setup_sender('Rulan', room=1)
         result = self._run(ctx, '#haven')
         self.assertTrue(result.success)
-        self.assertTrue(ctx.player.command_settings.haven)
+        self.assertTrue(ctx.player.command_settings.page.haven)
         self.assertTrue(ctx.player.unsaved_changes)
 
         sender_ctx = _add_player(server, 'Alice', room=1)
@@ -837,16 +839,16 @@ class TestPageControlWords(unittest.TestCase):
 
     def test_unhaven_reverses_haven(self):
         ctx, _ = _setup_sender('Rulan')
-        ctx.player.command_settings.haven = True
+        ctx.player.command_settings.page.haven = True
         result = self._run(ctx, '#unhaven')
         self.assertTrue(result.success)
-        self.assertFalse(ctx.player.command_settings.haven)
+        self.assertFalse(ctx.player.command_settings.page.haven)
 
     def test_ignore_blocks_specific_sender(self):
         ctx, server = _setup_sender('Rulan', room=1)
         result = self._run(ctx, '#ignore', 'Bob')
         self.assertTrue(result.success)
-        self.assertIn('Bob', ctx.player.command_settings.ignored_pagers)
+        self.assertIn('Bob', ctx.player.command_settings.page.ignored_pagers)
 
         bob_ctx = _add_player(server, 'Bob', room=1)
         self._run(bob_ctx, 'Rulan=hi there')
@@ -862,10 +864,10 @@ class TestPageControlWords(unittest.TestCase):
 
     def test_unignore_reverses_ignore(self):
         ctx, server = _setup_sender('Rulan', room=1)
-        ctx.player.command_settings.ignored_pagers = ['Bob']
+        ctx.player.command_settings.page.ignored_pagers = ['Bob']
         result = self._run(ctx, '#unignore', 'Bob')
         self.assertTrue(result.success)
-        self.assertNotIn('Bob', ctx.player.command_settings.ignored_pagers)
+        self.assertNotIn('Bob', ctx.player.command_settings.page.ignored_pagers)
 
         bob_ctx = _add_player(server, 'Bob', room=1)
         self._run(bob_ctx, 'Rulan=hi again')
@@ -1089,8 +1091,8 @@ class TestWhisperReply(unittest.TestCase):
         ctx, server = _setup_sender('Rulan', room=1)
         alice_ctx   = _add_player(server, 'Alice', room=1)
         self._run(ctx, 'Alice=hi')
-        self.assertEqual(ctx.player.command_settings.last_whispered, 'Alice')
-        self.assertEqual(alice_ctx.player.command_settings.last_whispered, 'Rulan')
+        self.assertEqual(ctx.player.command_settings.whisper.last_whispered, 'Alice')
+        self.assertEqual(alice_ctx.player.command_settings.whisper.last_whispered, 'Rulan')
         self.assertTrue(ctx.player.unsaved_changes)
         self.assertTrue(alice_ctx.player.unsaved_changes)
 
@@ -1106,7 +1108,7 @@ class TestWhisperReply(unittest.TestCase):
     def test_reply_short_and_long_forms_equivalent(self):
         ctx, server = _setup_sender('Rulan', room=1)
         alice_ctx   = _add_player(server, 'Alice', room=1)
-        ctx.player.command_settings.last_whispered = 'Alice'
+        ctx.player.command_settings.whisper.last_whispered = 'Alice'
         self._run(ctx, '#reply=one')
         self._run(ctx, '#r=two')
         self.assertIn('one', alice_ctx.sent_text())
@@ -1132,8 +1134,8 @@ class TestPageReply(unittest.TestCase):
         ctx, server = _setup_sender('Rulan', room=1)
         alice_ctx   = _add_player(server, 'Alice', room=7)
         self._run(ctx, 'Alice=ping')
-        self.assertEqual(ctx.player.command_settings.last_paged, 'Alice')
-        self.assertEqual(alice_ctx.player.command_settings.last_paged, 'Rulan')
+        self.assertEqual(ctx.player.command_settings.page.last_paged, 'Alice')
+        self.assertEqual(alice_ctx.player.command_settings.page.last_paged, 'Rulan')
 
     def test_reply_targets_last_correspondent(self):
         ctx, server = _setup_sender('Rulan', room=1)
@@ -1146,9 +1148,9 @@ class TestPageReply(unittest.TestCase):
     def test_reply_updates_pointer_after_use(self):
         ctx, server = _setup_sender('Rulan', room=1)
         alice_ctx   = _add_player(server, 'Alice', room=7)
-        ctx.player.command_settings.last_paged = 'Alice'
+        ctx.player.command_settings.page.last_paged = 'Alice'
         self._run(ctx, '#r=hi')
-        self.assertEqual(ctx.player.command_settings.last_paged, 'Alice')
+        self.assertEqual(ctx.player.command_settings.page.last_paged, 'Alice')
         self.assertIn('hi', alice_ctx.sent_text())
 
 
@@ -1156,16 +1158,256 @@ class TestReplySettingsRoundTrip(unittest.TestCase):
 
     def test_last_fields_default_none(self):
         cs = CommandSettings()
-        self.assertIsNone(cs.last_paged)
-        self.assertIsNone(cs.last_whispered)
+        self.assertIsNone(cs.page.last_paged)
+        self.assertIsNone(cs.whisper.last_whispered)
 
     def test_round_trip_preserves_last_fields(self):
         cs = CommandSettings()
-        cs.last_paged = 'Alice'
-        cs.last_whispered = 'Bob'
+        cs.page.last_paged = 'Alice'
+        cs.whisper.last_whispered = 'Bob'
         restored = CommandSettings.from_dict(json.loads(json.dumps(cs.to_dict())))
-        self.assertEqual(restored.last_paged, 'Alice')
-        self.assertEqual(restored.last_whispered, 'Bob')
+        self.assertEqual(restored.page.last_paged, 'Alice')
+        self.assertEqual(restored.whisper.last_whispered, 'Bob')
+
+    def test_from_dict_migrates_legacy_flat_haven_and_ignored(self):
+        # Older save files stored haven / ignored_pagers as flat
+        # CommandSettings fields, before the command_settings.page namespace.
+        restored = CommandSettings.from_dict({
+            'haven': True,
+            'ignored_pagers': ['Bob', 'Carol'],
+        })
+        self.assertTrue(restored.page.haven)
+        self.assertEqual(restored.page.ignored_pagers, ['Bob', 'Carol'])
+
+    def test_from_dict_prefers_nested_page_over_legacy_flat(self):
+        restored = CommandSettings.from_dict({
+            'haven': True,                       # legacy, should be ignored
+            'page': {'haven': False, 'last_limit': 9},
+        })
+        self.assertFalse(restored.page.haven)
+        self.assertEqual(restored.page.last_limit, 9)
+
+
+# ---------------------------------------------------------------------------
+# #last history helpers
+# ---------------------------------------------------------------------------
+
+class TestRecordMessageTarget(unittest.TestCase):
+
+    def test_prepends_newest_first(self):
+        h = []
+        record_message_target(h, 'Alice')
+        record_message_target(h, 'Bob')
+        self.assertEqual([e['name'] for e in h], ['Bob', 'Alice'])
+
+    def test_each_entry_has_timestamp(self):
+        h = []
+        record_message_target(h, 'Alice')
+        self.assertIn('at', h[0])
+        # parseable isoformat
+        import datetime
+        datetime.datetime.fromisoformat(h[0]['at'])
+
+    def test_dedupes_case_insensitively_and_moves_to_front(self):
+        h = []
+        for n in ('Alice', 'Bob', 'alice'):
+            record_message_target(h, n)
+        self.assertEqual([e['name'] for e in h], ['alice', 'Bob'])
+
+    def test_capped_at_history_cap(self):
+        h = []
+        for i in range(LAST_HISTORY_CAP + 5):
+            record_message_target(h, f'P{i}')
+        self.assertEqual(len(h), LAST_HISTORY_CAP)
+        self.assertEqual(h[0]['name'], f'P{LAST_HISTORY_CAP + 4}')
+
+
+class TestRelativeAge(unittest.TestCase):
+
+    def _iso_ago(self, **kw):
+        import datetime
+        return (datetime.datetime.now() - datetime.timedelta(**kw)).isoformat()
+
+    def test_just_now(self):
+        self.assertEqual(_relative_age(self._iso_ago(seconds=5)), 'just now')
+
+    def test_minutes(self):
+        self.assertEqual(_relative_age(self._iso_ago(minutes=10)), '10m ago')
+
+    def test_hours(self):
+        self.assertEqual(_relative_age(self._iso_ago(hours=3)), '3h ago')
+
+    def test_days(self):
+        self.assertEqual(_relative_age(self._iso_ago(days=2)), '2d ago')
+
+    def test_garbage_returns_placeholder(self):
+        self.assertEqual(_relative_age('not-a-date'), '?')
+        self.assertEqual(_relative_age(None), '?')
+
+
+class TestRenderLastHistory(unittest.TestCase):
+
+    def test_empty(self):
+        lines = render_last_history([], 5, verb='paged')
+        self.assertEqual(lines, ['You have not paged anyone yet.'])
+
+    def test_singular_header(self):
+        h = [{'name': 'Alice', 'at': 'not-a-date'}]
+        lines = render_last_history(h, 5, verb='paged')
+        self.assertEqual(lines[0], 'Last person you paged:')
+        self.assertIn('Alice', lines[1])
+
+    def test_plural_header_and_limit(self):
+        h = [{'name': f'P{i}', 'at': 'x'} for i in range(8)]
+        lines = render_last_history(h, 3, verb='whispered')
+        self.assertEqual(lines[0], 'Last 3 people you whispered:')
+        self.assertEqual(len(lines), 4)  # header + 3
+
+
+class TestParseLastLimit(unittest.TestCase):
+
+    def test_no_tokens_means_display_only(self):
+        self.assertEqual(parse_last_limit(()), (None, None))
+
+    def test_valid_number(self):
+        self.assertEqual(parse_last_limit(('5',)), (5, None))
+
+    def test_boundary_values(self):
+        self.assertEqual(parse_last_limit(('1',)), (1, None))
+        self.assertEqual(parse_last_limit((str(LAST_LIMIT_MAX),)), (LAST_LIMIT_MAX, None))
+
+    def test_zero_rejected(self):
+        limit, err = parse_last_limit(('0',))
+        self.assertIsNone(limit)
+        self.assertIn('1 to', err)
+
+    def test_over_max_rejected(self):
+        limit, err = parse_last_limit((str(LAST_LIMIT_MAX + 1),))
+        self.assertIsNone(limit)
+        self.assertIn('1 to', err)
+
+    def test_non_numeric_rejected(self):
+        limit, err = parse_last_limit(('abc',))
+        self.assertIsNone(limit)
+        self.assertIn('Usage', err)
+
+
+# ---------------------------------------------------------------------------
+# PageCommand / WhisperCommand — #last
+# ---------------------------------------------------------------------------
+
+class TestPageLast(unittest.TestCase):
+
+    def _run(self, ctx, *args):
+        return asyncio.run(PageCommand().execute(ctx, *args))
+
+    def test_empty_history_message(self):
+        ctx, _ = _setup_sender('Rulan')
+        result = self._run(ctx, '#last')
+        self.assertTrue(result.success)
+        self.assertIn('have not paged anyone', ctx.sent_text().lower())
+
+    def test_lists_after_paging(self):
+        ctx, server = _setup_sender('Rulan', room=1)
+        _add_player(server, 'Alice', room=2)
+        _add_player(server, 'Bob', room=2)
+        self._run(ctx, 'Alice=hi')
+        self._run(ctx, 'Bob=yo')
+        ctx._sent.clear()
+        self._run(ctx, '#last')
+        text = ctx.sent_text()
+        self.assertIn('Bob', text)
+        self.assertIn('Alice', text)
+        # newest first
+        self.assertLess(text.index('Bob'), text.index('Alice'))
+
+    def test_multi_target_records_all(self):
+        ctx, server = _setup_sender('Rulan', room=1)
+        _add_player(server, 'Alice', room=1)
+        _add_player(server, 'Bob', room=1)
+        self._run(ctx, 'Alice,Bob=party')
+        names = [e['name'] for e in ctx.player.command_settings.page.history]
+        self.assertCountEqual(names, ['Alice', 'Bob'])
+
+    def test_repeat_page_dedupes_history(self):
+        ctx, server = _setup_sender('Rulan', room=1)
+        _add_player(server, 'Alice', room=2)
+        self._run(ctx, 'Alice=one')
+        self._run(ctx, 'Alice=two')
+        self.assertEqual(
+            [e['name'] for e in ctx.player.command_settings.page.history], ['Alice'])
+
+    def test_number_sets_persisted_limit(self):
+        ctx, _ = _setup_sender('Rulan')
+        self._run(ctx, '#last', '3')
+        self.assertEqual(ctx.player.command_settings.page.last_limit, 3)
+        self.assertTrue(ctx.player.unsaved_changes)
+
+    def test_number_out_of_range_rejected(self):
+        ctx, _ = _setup_sender('Rulan')
+        result = self._run(ctx, '#last', '99')
+        self.assertFalse(result.success)
+        self.assertEqual(ctx.player.command_settings.page.last_limit, 5)
+
+    def test_limit_caps_displayed_rows(self):
+        ctx, server = _setup_sender('Rulan', room=1)
+        for i in range(6):
+            _add_player(server, f'P{i}', room=2)
+            self._run(ctx, f'P{i}=hi')
+        self._run(ctx, '#last', '2')
+        ctx._sent.clear()
+        self._run(ctx, '#last')
+        # header + exactly 2 rows
+        body = [ln for ln in ctx.sent_text().splitlines() if ln.strip()]
+        self.assertEqual(len(body), 3)
+
+
+class TestWhisperLast(unittest.TestCase):
+
+    def _run(self, ctx, *args):
+        return asyncio.run(WhisperCommand().execute(ctx, *args))
+
+    def test_empty_history_message(self):
+        ctx, _ = _setup_sender('Rulan')
+        result = self._run(ctx, '#last')
+        self.assertTrue(result.success)
+        self.assertIn('have not whispered anyone', ctx.sent_text().lower())
+
+    def test_lists_after_whispering(self):
+        ctx, server = _setup_sender('Rulan', room=1)
+        _add_player(server, 'Alice', room=1)
+        self._run(ctx, 'Alice=hi')
+        ctx._sent.clear()
+        self._run(ctx, '#last')
+        self.assertIn('Alice', ctx.sent_text())
+
+    def test_number_sets_persisted_limit(self):
+        ctx, _ = _setup_sender('Rulan')
+        self._run(ctx, '#last', '7')
+        self.assertEqual(ctx.player.command_settings.whisper.last_limit, 7)
+
+    def test_non_numeric_arg_rejected(self):
+        ctx, _ = _setup_sender('Rulan')
+        result = self._run(ctx, '#last', 'foo')
+        self.assertFalse(result.success)
+
+
+class TestLastSettingsRoundTrip(unittest.TestCase):
+
+    def test_defaults(self):
+        cs = CommandSettings()
+        self.assertEqual(cs.page.history, [])
+        self.assertEqual(cs.whisper.history, [])
+        self.assertEqual(cs.page.last_limit, 5)
+        self.assertEqual(cs.whisper.last_limit, 5)
+
+    def test_round_trip(self):
+        cs = CommandSettings()
+        cs.page.history = [{'name': 'Alice', 'at': '2026-09-09T12:00:00'}]
+        cs.whisper.last_limit = 8
+        restored = CommandSettings.from_dict(json.loads(json.dumps(cs.to_dict())))
+        self.assertEqual(restored.page.history, [{'name': 'Alice', 'at': '2026-09-09T12:00:00'}])
+        self.assertEqual(restored.whisper.last_limit, 8)
 
 
 if __name__ == '__main__':

--- a/server/tests/social/test_messaging.py
+++ b/server/tests/social/test_messaging.py
@@ -20,7 +20,7 @@ import unittest.mock
 from command_settings import CommandSettings
 from commands.messaging import (
     parse_targets, expand_groups, find_online,
-    prompt_player_choice,
+    prompt_player_choice, substitute_reply,
 )
 from tada_utilities import online_player_names, is_online, player_exists, find_players
 from commands.groups import GroupsCommand
@@ -1028,6 +1028,144 @@ class TestPageOfflineMail(unittest.TestCase):
             self.assertEqual(saved[0]['from'], 'Rulan')
             self.assertEqual(saved[0]['body'], 'hello there')
             self.assertFalse(saved[0]['read'])
+
+
+# ---------------------------------------------------------------------------
+# substitute_reply
+# ---------------------------------------------------------------------------
+
+class TestSubstituteReply(unittest.TestCase):
+
+    def test_no_token_passthrough(self):
+        out, unresolved = substitute_reply(['Alice', 'Bob'], 'Carol')
+        self.assertEqual(out, ['Alice', 'Bob'])
+        self.assertFalse(unresolved)
+
+    def test_reply_token_replaced(self):
+        out, unresolved = substitute_reply(['#reply'], 'Carol')
+        self.assertEqual(out, ['Carol'])
+        self.assertFalse(unresolved)
+
+    def test_short_token_replaced(self):
+        out, unresolved = substitute_reply(['#r'], 'Carol')
+        self.assertEqual(out, ['Carol'])
+        self.assertFalse(unresolved)
+
+    def test_token_case_insensitive(self):
+        out, _ = substitute_reply(['#Reply'], 'Carol')
+        self.assertEqual(out, ['Carol'])
+
+    def test_token_mixed_with_plain_names(self):
+        out, _ = substitute_reply(['Alice', '#r'], 'Carol')
+        self.assertEqual(out, ['Alice', 'Carol'])
+
+    def test_unresolved_when_no_last_name(self):
+        out, unresolved = substitute_reply(['#r'], None)
+        self.assertEqual(out, ['#r'])
+        self.assertTrue(unresolved)
+
+    def test_no_token_and_no_last_name_is_fine(self):
+        out, unresolved = substitute_reply(['Alice'], None)
+        self.assertEqual(out, ['Alice'])
+        self.assertFalse(unresolved)
+
+
+# ---------------------------------------------------------------------------
+# WhisperCommand — #reply / #r
+# ---------------------------------------------------------------------------
+
+class TestWhisperReply(unittest.TestCase):
+
+    def _run(self, ctx, *args):
+        return asyncio.run(WhisperCommand().execute(ctx, *args))
+
+    def test_reply_with_nothing_saved_errors(self):
+        ctx, _ = _setup_sender('Rulan')
+        result = self._run(ctx, "#r=hello")
+        self.assertFalse(result.success)
+        self.assertIn("haven't whispered", ctx.sent_text().lower())
+
+    def test_send_records_last_whispered_on_both_sides(self):
+        ctx, server = _setup_sender('Rulan', room=1)
+        alice_ctx   = _add_player(server, 'Alice', room=1)
+        self._run(ctx, 'Alice=hi')
+        self.assertEqual(ctx.player.command_settings.last_whispered, 'Alice')
+        self.assertEqual(alice_ctx.player.command_settings.last_whispered, 'Rulan')
+        self.assertTrue(ctx.player.unsaved_changes)
+        self.assertTrue(alice_ctx.player.unsaved_changes)
+
+    def test_reply_targets_last_correspondent(self):
+        ctx, server = _setup_sender('Rulan', room=1)
+        alice_ctx   = _add_player(server, 'Alice', room=1)
+        # Alice whispers Rulan first; Rulan replies with #r
+        asyncio.run(WhisperCommand().execute(alice_ctx, 'Rulan=you there?'))
+        self._run(ctx, '#r=yes I am')
+        self.assertIn('yes I am', alice_ctx.sent_text())
+        self.assertIn('Rulan whispers to you', alice_ctx.sent_text())
+
+    def test_reply_short_and_long_forms_equivalent(self):
+        ctx, server = _setup_sender('Rulan', room=1)
+        alice_ctx   = _add_player(server, 'Alice', room=1)
+        ctx.player.command_settings.last_whispered = 'Alice'
+        self._run(ctx, '#reply=one')
+        self._run(ctx, '#r=two')
+        self.assertIn('one', alice_ctx.sent_text())
+        self.assertIn('two', alice_ctx.sent_text())
+
+
+# ---------------------------------------------------------------------------
+# PageCommand — #reply / #r
+# ---------------------------------------------------------------------------
+
+class TestPageReply(unittest.TestCase):
+
+    def _run(self, ctx, *args):
+        return asyncio.run(PageCommand().execute(ctx, *args))
+
+    def test_reply_with_nothing_saved_errors(self):
+        ctx, _ = _setup_sender('Rulan')
+        result = self._run(ctx, '#r=hello')
+        self.assertFalse(result.success)
+        self.assertIn("haven't paged", ctx.sent_text().lower())
+
+    def test_send_records_last_paged_on_both_sides(self):
+        ctx, server = _setup_sender('Rulan', room=1)
+        alice_ctx   = _add_player(server, 'Alice', room=7)
+        self._run(ctx, 'Alice=ping')
+        self.assertEqual(ctx.player.command_settings.last_paged, 'Alice')
+        self.assertEqual(alice_ctx.player.command_settings.last_paged, 'Rulan')
+
+    def test_reply_targets_last_correspondent(self):
+        ctx, server = _setup_sender('Rulan', room=1)
+        alice_ctx   = _add_player(server, 'Alice', room=7)
+        asyncio.run(PageCommand().execute(alice_ctx, 'Rulan=where are you?'))
+        self._run(ctx, '#r=on my way')
+        self.assertIn('on my way', alice_ctx.sent_text())
+        self.assertIn('Rulan pages you', alice_ctx.sent_text())
+
+    def test_reply_updates_pointer_after_use(self):
+        ctx, server = _setup_sender('Rulan', room=1)
+        alice_ctx   = _add_player(server, 'Alice', room=7)
+        ctx.player.command_settings.last_paged = 'Alice'
+        self._run(ctx, '#r=hi')
+        self.assertEqual(ctx.player.command_settings.last_paged, 'Alice')
+        self.assertIn('hi', alice_ctx.sent_text())
+
+
+class TestReplySettingsRoundTrip(unittest.TestCase):
+
+    def test_last_fields_default_none(self):
+        cs = CommandSettings()
+        self.assertIsNone(cs.last_paged)
+        self.assertIsNone(cs.last_whispered)
+
+    def test_round_trip_preserves_last_fields(self):
+        cs = CommandSettings()
+        cs.last_paged = 'Alice'
+        cs.last_whispered = 'Bob'
+        restored = CommandSettings.from_dict(json.loads(json.dumps(cs.to_dict())))
+        self.assertEqual(restored.last_paged, 'Alice')
+        self.assertEqual(restored.last_whispered, 'Bob')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## page / whisper get two new control tokens

### `#reply` / `#r` — reply without retyping a name
- `page #r=on my way` / `whisper #r=me too` (also `#reply`) target whoever you last exchanged that kind of private message **with**.
- Remembered per-channel in `command_settings.page.last_paged` / `command_settings.whisper.last_whispered`, updated on **both send and receive** so it works from either side. Combat-queued pages and the offline mail fallback count as sends.
- No correspondent yet -> *"You haven't paged/whispered anyone yet."*, command fails without sending.
- Resolved before group expansion, so `#r` / `#reply` shadow any identically-named saved group (same as `page`'s `#ignore` / `#haven`).

### `#last [N]` — recent-recipient history
- `page #last` / `whisper #last` list who you've recently paged/whispered, newest first, each with a relative timestamp (`just now` / `5m ago` / `3h ago` / `2d ago`).
- `page #last N` (1-10) saves how many lines to show (`command_settings.page.last_limit` / `whisper.last_limit`).
- History is a per-channel ring buffer of `{name, at}`, de-duped by name, capped at 10; a multi-target page/whisper records every recipient.
- `#last` is a reserved `page` control word alongside `#ignore` / `#haven`.

## `command_settings.page` / `command_settings.whisper` namespace

All page/whisper preferences now live under two nested dataclasses:

- `PageSettings(haven, ignored_pagers, last_paged, history, last_limit)`
- `WhisperSettings(last_whispered, history, last_limit)`

`CommandSettings.from_dict()` handles the nested `page` / `whisper` blocks and, for older save files, folds flat `haven` / `ignored_pagers` into `page.*` when no nested `page` block is present.

## editplayer

`Command Settings` menu (under `command_settings.page` / `.whisper`):
- **Last Paged** (`lp`) / **Last Whispered** (`lw`) — set to a validated player (canonical casing), `-` clears, `Enter` cancels.
- **Page #last Limit** (`pl`) / **Whisper #last Limit** (`wl`) — integer 1-10.
- **Page History** (`ph`) / **Whisper History** (`wht`) — show the list, prompt to clear.

## Files

`command_settings.py`, `commands/messaging.py` (shared helpers: `substitute_reply`, `record_message_target`, `_relative_age`, `render_last_history`, `parse_last_limit`), `commands/page.py`, `commands/whisper.py`, `commands/editplayer.py`; tests in `tests/social/test_messaging.py`, `tests/admin/test_editplayer.py`, `tests/social/test_mail_command.py`.

## Testing

`pytest -q -m ""` (full CI-equivalent suite): **4656 passed, 2 skipped, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
