### PR TITLE
Fix #<switch> consistency: board.py, map.py/teleport.py, news.py/banner_edit.py

### DIFF
--- a/server/MECHANICS.md
+++ b/server/MECHANICS.md
@@ -1298,7 +1298,7 @@ for exactly this reason.
 - ✅ **Startup display** — `commands/connect.py`'s `_login_news_lines()` shows applicable news
   items automatically at login, before the game loop starts.
 - ✅ **`news` command** (`commands/news.py`) — `news` lists currently-active items, `news <id>`
-  reads one in full, `news post` / `news edit <id>` / `news delete <id>` are admin-only.
+  reads one in full, `news #post` / `news #edit <id>` / `news #delete <id>` are admin-only.
 - ✅ **Display lifetime** — each post (`news.py`) carries one of three lifetime modes:
   - *once* — shown once per player, then silently suppressed (tracked via `seen_by`).
   - *permanent* — always shown until manually deleted.
@@ -1309,7 +1309,7 @@ for exactly this reason.
 - ✅ **Per-player display preference** — `command_settings.news_show_all` (PREFS key `N`)
   chooses between a full directory every login vs. just what's new since
   `player.last_connection`.
-- ✅ **Post editing via the shared line editor** — admin authoring (`news post` / `news edit
+- ✅ **Post editing via the shared line editor** — admin authoring (`news #post` / `news #edit
   <id>`) uses `text_editor.run_editor()`, the same `ed`-style line editor used by MAIL's long-form
   composing below (`commands/news.py`).
 

--- a/server/commands/banner_edit.py
+++ b/server/commands/banner_edit.py
@@ -40,8 +40,8 @@ class BannerEditCommand(Command):
         summary  = 'Edit a PETSCII banner/screen on your Commodore 64.',
         category = HelpCategory.ADMINISTRATIVE,
         usage    = [
-            ('banner edit <name>', 'Open (or create) a named banner in the visual editor.'),
-            ('banner list',        'List saved banners.'),
+            ('banner #edit <name>', 'Open (or create) a named banner in the visual editor.'),
+            ('banner #list',        'List saved banners.'),
         ],
         notes = [
             'Admin-only. Requires a real Commodore connection -- there\'s '
@@ -54,21 +54,33 @@ class BannerEditCommand(Command):
             await ctx.send('You lack the authority to do that.')
             return CommandResult.fail('Permission denied.', error='permission_denied')
 
-        positional, _switches = self.parse_args(*args)
-        if not positional:
-            await ctx.send('Usage: banner edit <name> | banner list')
+        positional, switches = self.parse_args(*args)
+        sub = switches[0].lstrip('#').lower() if switches else ''
+
+        if not sub:
+            # 'list'/'edit' are '#'-only switches, not bare positional
+            # words -- a bare word here used to work as sub, *rest =
+            # positional. Catch the specific bare-'list'/'edit' case and
+            # hint at the right syntax instead of falling into the
+            # generic "no subcommand" message below, same as news.py's
+            # own catch for this switch-consistency audit.
+            if positional and positional[0].lower() in ('list', 'edit'):
+                bare = positional[0].lower()
+                hint = f'banner #{bare}' + (' <name>' if bare == 'edit' else '')
+                await ctx.send(f"'{bare}' needs a '#' -- try '{hint}'.")
+                return CommandResult.fail('Missing #.', error='missing_hash')
+            await ctx.send('Usage: banner #edit <name> | banner #list')
             return CommandResult.fail('No subcommand given.')
 
-        sub, *rest = positional
         if sub == 'list':
             return await self._list(ctx)
         if sub == 'edit':
-            if not rest:
-                await ctx.send('Edit which banner? (banner edit <name>)')
+            if not positional:
+                await ctx.send('Edit which banner? (banner #edit <name>)')
                 return CommandResult.fail('No banner name given.')
-            return await self._edit(ctx, ' '.join(rest))
+            return await self._edit(ctx, ' '.join(positional))
 
-        await ctx.send(f'Unknown "banner" subcommand: {sub!r}. Try "banner list" or "banner edit <name>".')
+        await ctx.send(f'Unknown "banner" subcommand: {sub!r}. Try "banner #list" or "banner #edit <name>".')
         return CommandResult.fail('Unknown subcommand.', error='unknown_subcommand')
 
     async def _list(self, ctx) -> CommandResult:

--- a/server/commands/board/board.py
+++ b/server/commands/board/board.py
@@ -377,7 +377,7 @@ class BoardCommand(Command):
             ('board post',        'Start a new thread.'),
             ('board reply <id>',  'Reply to a thread.'),
             ('board delete <id>', '(Admin) Remove a thread.'),
-            ('board #edit',       '(Admin) Board-wide settings menu.'),
+            ('board edit',        '(Admin) Board-wide settings menu.'),
         ],
         notes = [
             "Bare 'board' stays in the listing -- press Enter with no "
@@ -395,8 +395,9 @@ class BoardCommand(Command):
             "(for any player, not just yourself) via EditPlayer's Flags "
             "-> Option Toggles menu. See commands/board/reply.py for the "
             "interactive reader itself.",
-            "'board #edit' opens a small settings menu (currently just "
-            "the anonymous-posting default: Ask/Yes/No) -- see "
+            "'board edit' (the '#edit' switch spelling still works too, "
+            "for anyone used to it) opens a small settings menu (currently "
+            "just the anonymous-posting default: Ask/Yes/No) -- see "
             "commands/board/edit.py.",
         ],
     )
@@ -414,6 +415,19 @@ class BoardCommand(Command):
 
         sub = positional[0].lower() if positional else ''
 
+        if sub == 'edit':
+            # Bare 'board edit', not just '#edit' -- every other sub-action
+            # here (post/reply/delete/rn/ra/sa/ld) is a bare positional
+            # word, so '#edit' alone was the only one requiring the '#'
+            # cue. Without this, 'board edit' silently fell through every
+            # sub== check below (never matching), then positional[0].
+            # isdigit() (False), landing on the final `return await
+            # self._list(ctx)` -- indistinguishable from bare 'board', with
+            # no error and no hint that '#edit' was needed. edit_board_
+            # settings() enforces its own admin check, same as the
+            # '#edit' branch above.
+            from commands.board.edit import edit_board_settings
+            return await edit_board_settings(ctx)
         if sub == 'post':
             return await self._post(ctx)
         if sub == 'reply' and len(positional) > 1:

--- a/server/commands/edit.py
+++ b/server/commands/edit.py
@@ -24,7 +24,7 @@ news_store.save_news(). See _RESUME_HANDLERS below. A recovered new post
 lands with sane defaults for anything that genuinely can't survive a
 crash (a fresh news post's admin-picked lifetime, since that's collected
 even earlier than the title) -- 'permanent' until the admin narrows it
-with 'news edit <id>'. Anything whose activity_id has no registered
+with 'news #edit <id>'. Anything whose activity_id has no registered
 handler falls back to a plain personal text file the player can review
 and repost by hand.
 """
@@ -97,7 +97,7 @@ async def _resume_news_post(ctx, rest: str, body: list) -> Optional[str]:
     """rest is the title verbatim (no admin-picked lifetime survives a
     crash, since that's collected before the editor opens) -- posted as
     'permanent' by default; the admin can narrow it afterwards with
-    'news edit <id>'."""
+    'news #edit <id>'."""
     import datetime
     import news as news_store
     if not rest:
@@ -115,7 +115,7 @@ async def _resume_news_post(ctx, rest: str, body: list) -> Optional[str]:
     items.append(item)
     news_store.save_news(items)
     return (f"News item #{item['id']} posted (as \"permanent\" -- "
-            f"use 'news edit {item['id']}' to change that).")
+            f"use 'news #edit {item['id']}' to change that).")
 
 
 async def _resume_board_post(ctx, rest: str, body: list) -> Optional[str]:

--- a/server/commands/map.py
+++ b/server/commands/map.py
@@ -559,7 +559,26 @@ class MapCommand(Command):
     async def execute(self, ctx: GameContext, *args) -> CommandResult:
         player = ctx.player
 
-        if args and args[0].lower().lstrip('#') == 'overview':
+        # Same '#edit'-or-bare convention as board.py/groups.py/whereat.py:
+        # a '#'-prefixed sub-word routes into switches (parse_args() only
+        # buckets '#'-prefixed tokens there), a bare one lands in
+        # positional. Unlike those commands, every sub-word here has
+        # always accepted *either* form (see this class's own Help(usage=)
+        # -- 'map grid' and 'map #grid' are explicitly documented as the
+        # same command) -- this parses both/either uniformly instead of
+        # each branch below hand-rolling its own args[0].lower().
+        # lstrip('#') check. 'rest' is whatever's left after the sub-word
+        # (the optional <level> argument), regardless of which list the
+        # sub-word itself came from.
+        positional, switches = self.parse_args(*args)
+        if switches:
+            sub  = switches[0].lstrip('#').lower()
+            rest = positional
+        else:
+            sub  = positional[0].lower() if positional else ''
+            rest = positional[1:]
+
+        if sub == 'overview':
             if not _is_debug(player):
                 await ctx.send("You need Debug Mode on for that -- see the DBG command.")
                 return CommandResult.fail('Not in debug mode.', error='not_debug')
@@ -569,11 +588,11 @@ class MapCommand(Command):
                 await ctx.send('You lose your bearings -- no map data here.')
                 return CommandResult.fail('No map data.', error='no_map')
 
-            if len(args) > 1:
+            if rest:
                 try:
-                    level = int(args[1])
+                    level = int(rest[0])
                 except ValueError:
-                    await ctx.send(f'"{args[1]}" is not a level number.')
+                    await ctx.send(f'"{rest[0]}" is not a level number.')
                     return CommandResult.fail('Bad level.', error='bad_level')
             else:
                 level = player.map_level
@@ -585,17 +604,17 @@ class MapCommand(Command):
             await ctx.send([f'|yellow|Level {level} overview|reset|', ''] + lines)
             return CommandResult.ok('Showed level overview.')
 
-        if args and args[0].lower().lstrip('#') == 'visited':
+        if sub == 'visited':
             game_map = getattr(ctx.server, 'game_map', None)
             if not game_map:
                 await ctx.send('You lose your bearings -- no map data here.')
                 return CommandResult.fail('No map data.', error='no_map')
 
-            if len(args) > 1:
+            if rest:
                 try:
-                    level = int(args[1])
+                    level = int(rest[0])
                 except ValueError:
-                    await ctx.send(f'"{args[1]}" is not a level number.')
+                    await ctx.send(f'"{rest[0]}" is not a level number.')
                     return CommandResult.fail('Bad level.', error='bad_level')
             else:
                 level = player.map_level
@@ -625,7 +644,7 @@ class MapCommand(Command):
             await ctx.send('You lose your bearings -- no map data here.')
             return CommandResult.fail('No room data.', error='no_map')
 
-        if args and args[0].lower().lstrip('#') == 'grid':
+        if sub == 'grid':
             lines = render_ansi_grid(ctx, game_map, player.map_level, player, _BFS_DEPTH)
             await ctx.send(lines)
             return CommandResult.ok('Showed nearby rooms as a grid.')

--- a/server/commands/news.py
+++ b/server/commands/news.py
@@ -6,9 +6,9 @@ the in-game command surface:
 
   news                 — list currently-active items (title + id + date)
   news <id>            — read one item in full, marks 'once' items seen
-  news post            — (admin) write a new item
-  news edit <id>       — (admin) change an existing item's body/lifetime
-  news delete <id>     — (admin) remove an item
+  news #post           — (admin) write a new item
+  news #edit <id>      — (admin) change an existing item's body/lifetime
+  news #delete <id>    — (admin) remove an item
 
 Login-time display ("what's new since you last logged in") is handled by
 commands/connect.py, which calls the same news.py helpers this command uses
@@ -53,9 +53,9 @@ class NewsCommand(Command):
         usage    = [
             ('news',            'List currently-active news items.'),
             ('news <id>',       'Read one item in full.'),
-            ('news post',       '(Admin) Write a new news item.'),
-            ('news edit <id>',  '(Admin) Edit an existing item.'),
-            ('news delete <id>', '(Admin) Remove an item.'),
+            ('news #post',       '(Admin) Write a new news item.'),
+            ('news #edit <id>',  '(Admin) Edit an existing item.'),
+            ('news #delete <id>', '(Admin) Remove an item.'),
         ],
         notes = [
             "Whether NEWS shows just what's new since your last login or "
@@ -66,17 +66,29 @@ class NewsCommand(Command):
     )
 
     async def execute(self, ctx, *args) -> CommandResult:
-        positional, _ = self.parse_args(*args)
-        sub = positional[0].lower() if positional else ''
+        positional, switches = self.parse_args(*args)
+        sub = switches[0].lstrip('#').lower() if switches else ''
 
         if sub == 'post':
             return await self._post(ctx)
-        if sub == 'edit' and len(positional) > 1:
-            return await self._edit(ctx, positional[1])
-        if sub == 'delete' and len(positional) > 1:
-            return await self._delete(ctx, positional[1])
+        if sub == 'edit' and positional:
+            return await self._edit(ctx, positional[0])
+        if sub == 'delete' and positional:
+            return await self._delete(ctx, positional[0])
         if positional and positional[0].isdigit():
             return await self._read_one(ctx, int(positional[0]))
+
+        # 'post'/'edit'/'delete' are '#'-only switches now, not bare
+        # positional words -- a bare 'news edit 5' (no leading '#') would
+        # otherwise match none of the sub== checks above and silently
+        # fall through to the plain listing below, the exact board.py-
+        # style bug this switch-consistency audit started with. Catch
+        # the bare word explicitly and point at the right syntax instead.
+        if positional and positional[0].lower() in ('post', 'edit', 'delete'):
+            bare = positional[0].lower()
+            hint = f'news #{bare}' + (' <id>' if bare != 'post' else '')
+            await ctx.send(f"'{bare}' needs a '#' -- try '{hint}'.")
+            return CommandResult.fail('Missing #.', error='missing_hash')
 
         return await self._list(ctx)
 
@@ -226,7 +238,7 @@ class NewsCommand(Command):
             return CommandResult.fail('Permission denied.', error='permission_denied')
 
         if not id_str.isdigit():
-            await ctx.send('Usage: news edit <id>')
+            await ctx.send('Usage: news #edit <id>')
             return CommandResult.fail('Bad id.', error='bad_args')
 
         items = news_store.load_news()
@@ -268,7 +280,7 @@ class NewsCommand(Command):
             return CommandResult.fail('Permission denied.', error='permission_denied')
 
         if not id_str.isdigit():
-            await ctx.send('Usage: news delete <id>')
+            await ctx.send('Usage: news #delete <id>')
             return CommandResult.fail('Bad id.', error='bad_args')
 
         items = news_store.load_news()

--- a/server/commands/teleport.py
+++ b/server/commands/teleport.py
@@ -166,23 +166,33 @@ class TeleportCommand(Command):
             await ctx.send('You lack the power to teleport.')
             return CommandResult.fail('Permission denied.', error='permission_denied')
 
-        # 'teleport #learn <name>' arrives as args=('#learn', <name...>);
-        # '#learn <name>' via the bare '#' alias loses its leading '#' in
-        # command_processor.process_command()'s '#<word>' splitting, so it
-        # arrives as args=('learn', <name...>) instead -- check the bare
-        # word either way rather than relying on parse_args' '#'-prefix
-        # switch detection. Same deal for '#list'/'#show'/'#find'/'#forget'.
-        first = args[0].lstrip('#').lower() if args else ''
-        if first == 'learn':
-            return await self._learn(ctx, args[1:])
-        if first in ('list', 'show'):
-            return await self._list_destinations(ctx)
-        if first == 'find':
-            return await self._find(ctx, args[1:])
-        if first == 'forget':
-            return await self._forget(ctx, args[1:])
+        # 'teleport #learn <name>' arrives as args=('#learn', <name...>),
+        # routed by self.parse_args() into switches; '#learn <name>' via
+        # the bare '#' alias loses its leading '#' in command_processor.
+        # process_command()'s '#<word>' splitting, so it arrives as
+        # args=('learn', <name...>) instead, routed into positional --
+        # check the bare word from whichever list parse_args() put it in,
+        # rather than assuming '#' survived. Same deal for '#list'/
+        # '#show'/'#find'/'#forget'. Same dual-list convention as
+        # map.py's own (documented) bare-or-'#' sub-words, and the same
+        # "if switches: ... else: positional[0] ..." shape as board.py/
+        # groups.py/whereat.py.
+        positional, switches = self.parse_args(*args)
+        if switches:
+            sub  = switches[0].lstrip('#').lower()
+            rest = positional
+        else:
+            sub  = positional[0].lower() if positional else ''
+            rest = positional[1:]
 
-        positional, _ = self.parse_args(*args)
+        if sub == 'learn':
+            return await self._learn(ctx, tuple(rest))
+        if sub in ('list', 'show'):
+            return await self._list_destinations(ctx)
+        if sub == 'find':
+            return await self._find(ctx, tuple(rest))
+        if sub == 'forget':
+            return await self._forget(ctx, tuple(rest))
 
         if not positional:
             await ctx.send('Usage: #<room number>  or  #<level> <room>  or  teleport <name fragment>')

--- a/server/tests/admin/test_banner_edit.py
+++ b/server/tests/admin/test_banner_edit.py
@@ -1,0 +1,129 @@
+"""tests/admin/test_banner_edit.py — Unit tests for commands/banner_edit.py's
+'banner' command: '#'-only switch dispatch (#list/#edit), same convention
+as reload.py/groups.py/whereat.py. No test file existed for this command
+before the switch-consistency audit that touched it (dropping bare
+'list'/'edit' positional words in favor of requiring '#').
+"""
+from __future__ import annotations
+
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from commands.banner_edit import BannerEditCommand
+from commands.base_command import CommandResult
+from flags import PlayerFlags
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def make_ctx(*, is_admin=True):
+    player = MagicMock()
+    player.name = 'Admin'
+    player.query_flag = MagicMock(
+        side_effect=lambda f: f == PlayerFlags.ADMIN and is_admin
+    )
+    ctx = MagicMock()
+    ctx.player = player
+    ctx.send   = AsyncMock()
+    return ctx
+
+
+class TestPermission(unittest.TestCase):
+    def test_non_admin_denied(self):
+        ctx = make_ctx(is_admin=False)
+        result = run(BannerEditCommand().execute(ctx, '#list'))
+        self.assertFalse(result.success)
+        self.assertEqual(result.error, 'permission_denied')
+
+
+class TestNoSubcommand(unittest.TestCase):
+    def test_bare_banner_shows_usage(self):
+        ctx = make_ctx()
+        result = run(BannerEditCommand().execute(ctx))
+        self.assertFalse(result.success)
+        sent = ' '.join(str(c) for c in ctx.send.await_args_list)
+        self.assertIn('#edit', sent)
+        self.assertIn('#list', sent)
+
+
+class TestBareSubwordsRejected(unittest.TestCase):
+    """'list'/'edit' are '#'-only switches -- a bare word here used to
+    work exactly like '#list'/'#edit' (sub, *rest = positional). These
+    lock in the explicit "needs a '#'" hint added alongside the #-only
+    conversion, so a regression back to silently accepting the bare word
+    (or silently doing nothing) is caught."""
+
+    def test_bare_list_hints_at_hash_form(self):
+        ctx = make_ctx()
+        result = run(BannerEditCommand().execute(ctx, 'list'))
+        self.assertFalse(result.success)
+        self.assertEqual(result.error, 'missing_hash')
+        sent = ' '.join(str(c) for c in ctx.send.await_args_list)
+        self.assertIn('#list', sent)
+
+    def test_bare_edit_hints_at_hash_form(self):
+        ctx = make_ctx()
+        result = run(BannerEditCommand().execute(ctx, 'edit', 'castle'))
+        self.assertFalse(result.success)
+        self.assertEqual(result.error, 'missing_hash')
+        sent = ' '.join(str(c) for c in ctx.send.await_args_list)
+        self.assertIn('#edit', sent)
+
+
+class TestListSwitch(unittest.TestCase):
+    def test_hash_list_with_no_banners(self):
+        ctx = make_ctx()
+        fake_dir = MagicMock()
+        fake_dir.is_dir.return_value = False
+        with patch('commands.banner_edit.canvas_store.CANVASES_DIR', fake_dir):
+            result = run(BannerEditCommand().execute(ctx, '#list'))
+        self.assertTrue(result.success)
+        sent = ' '.join(str(c) for c in ctx.send.await_args_list)
+        self.assertIn('No saved banners', sent)
+
+    def test_hash_list_shows_saved_names(self):
+        ctx = make_ctx()
+        fake_path = MagicMock()
+        fake_path.stem = 'castle'
+        fake_dir = MagicMock()
+        fake_dir.is_dir.return_value = True
+        fake_dir.glob.return_value = [fake_path]
+        with patch('commands.banner_edit.canvas_store.CANVASES_DIR', fake_dir):
+            result = run(BannerEditCommand().execute(ctx, '#list'))
+        self.assertTrue(result.success)
+        sent = ' '.join(str(c) for c in ctx.send.await_args_list)
+        self.assertIn('castle', sent)
+
+
+class TestEditSwitch(unittest.TestCase):
+    def test_hash_edit_without_name_prompts_for_one(self):
+        ctx = make_ctx()
+        result = run(BannerEditCommand().execute(ctx, '#edit'))
+        self.assertFalse(result.success)
+        sent = ' '.join(str(c) for c in ctx.send.await_args_list)
+        self.assertIn('#edit', sent)
+
+    def test_hash_edit_with_name_opens_the_editor(self):
+        ctx = make_ctx()
+        with patch('commands.banner_edit.canvas_store.path_for', return_value='castle.canvas'), \
+             patch('commands.banner_edit.stream_canvas_edit',
+                    new=AsyncMock(return_value=CommandResult.ok('Saved.'))) as mock_stream:
+            result = run(BannerEditCommand().execute(ctx, '#edit', 'castle'))
+        self.assertTrue(result.success)
+        mock_stream.assert_awaited_once()
+        self.assertEqual(mock_stream.call_args.args[1], 'castle.canvas')
+
+
+class TestUnknownSubcommand(unittest.TestCase):
+    def test_unknown_hash_switch_reports_error(self):
+        ctx = make_ctx()
+        result = run(BannerEditCommand().execute(ctx, '#bogus'))
+        self.assertFalse(result.success)
+        self.assertEqual(result.error, 'unknown_subcommand')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/server/tests/commands/test_edit_command.py
+++ b/server/tests/commands/test_edit_command.py
@@ -214,7 +214,7 @@ class TestDispatchResume(unittest.TestCase):
             result = run(edit_mod._dispatch_resume(
                 ctx, 'news_post:Server Maintenance: 8pm', [{'text': 'body'}]))
         self.assertEqual(result, 'News item #7 posted (as "permanent" -- '
-                                  "use 'news edit 7' to change that).")
+                                  "use 'news #edit 7' to change that).")
         mock_save.assert_called_once()
         posted = mock_save.call_args.args[0][0]
         self.assertEqual(posted['title'], 'Server Maintenance: 8pm')

--- a/server/tests/commands/test_map.py
+++ b/server/tests/commands/test_map.py
@@ -198,6 +198,50 @@ class TestMapOutput(unittest.TestCase):
         self.assertNotIn('Dwarf', text)
 
 
+class TestBareOrHashSubwordsAccepted(unittest.TestCase):
+    """MapCommand's own Help(usage=) explicitly documents 'map grid' and
+    'map #grid' as the same command -- unlike every other command with
+    sub-actions (board.py/groups.py/whereat.py/etc.), a '#' here has
+    always been optional, not a required cue. execute() now parses this
+    via self.parse_args() (switches vs. positional) instead of hand-
+    rolling args[0].lower().lstrip('#') in three separate places --
+    these lock in that both spellings still reach the same code path for
+    all three sub-words, not just the '#'-prefixed one most other tests
+    exercise."""
+
+    def test_grid_bare_and_hash_both_succeed(self):
+        for arg in ('grid', '#grid', 'GRID', '#GRID'):
+            with self.subTest(arg=arg):
+                player = make_player()
+                ctx = make_ctx(player, make_game_map(_sample_rooms()))
+                result = run(MapCommand().execute(ctx, arg))
+                self.assertTrue(result.success)
+
+    def test_overview_bare_and_hash_both_reach_debug_gate(self):
+        # Debug Mode off either way -- both spellings should hit the same
+        # "need Debug Mode" refusal, not diverge (e.g. bare 'overview'
+        # falling through to the ordinary nearby-rooms view instead).
+        for arg in ('overview', '#overview'):
+            with self.subTest(arg=arg):
+                player = make_player()
+                ctx = make_ctx(player, make_game_map(_sample_rooms()))
+                result = run(MapCommand().execute(ctx, arg))
+                self.assertFalse(result.success)
+                self.assertEqual(result.error, 'not_debug')
+
+    def test_visited_bare_and_hash_both_reach_the_same_handler(self):
+        # No visited rooms recorded either way -- both spellings should
+        # hit the same "haven't explored" refusal.
+        for arg in ('visited', '#visited'):
+            with self.subTest(arg=arg):
+                player = make_player()
+                player.visited_rooms = {}
+                ctx = make_ctx(player, make_game_map(_sample_rooms()))
+                result = run(MapCommand().execute(ctx, arg))
+                self.assertFalse(result.success)
+                self.assertEqual(result.error, 'no_visited')
+
+
 class TestRoomNumberPrivacy(unittest.TestCase):
     """Room numbers are only shown to privileged players (Admin/DM) --
     an ordinary player gets the direction path and room name only."""

--- a/server/tests/movement/test_teleport.py
+++ b/server/tests/movement/test_teleport.py
@@ -185,6 +185,20 @@ class TestTeleportListDestinations(unittest.IsolatedAsyncioTestCase):
         sent = ' '.join(str(c) for c in ctx.send.await_args_list)
         self.assertIn('armory', sent)
 
+    async def test_bare_list_without_hash_also_works(self):
+        # Bare 'list' (no '#') as the first arg -- arrives this way when
+        # TELEPORT is reached via its own bare '#list' shortcut, since
+        # command_processor.py strips the leading '#' before this ever
+        # sees it. See execute()'s own comment for why 'learn'/'forget'/
+        # 'find' each get a matching bare-word test but 'list'/'show'
+        # hadn't until now.
+        cmd = TeleportCommand()
+        ctx = make_named_ctx(destinations={'armory': (1, 37)})
+        res = await cmd.execute(ctx, 'list')
+        self.assertTrue(res.success)
+        sent = ' '.join(str(c) for c in ctx.send.await_args_list)
+        self.assertIn('armory', sent)
+
     async def test_bare_teleport_still_requires_args(self):
         # Bare 'teleport' with no args is NOT the same as '#list' -- it
         # still fails with the usage message (Ryan wanted an explicit

--- a/server/tests/social/test_board_command.py
+++ b/server/tests/social/test_board_command.py
@@ -524,6 +524,25 @@ class TestEditSwitch(BoardCommandTestCase):
         result = run(BoardCommand().execute(ctx, '#bogus'))
         self.assertFalse(result.success)
 
+    def test_bare_edit_also_reaches_the_settings_menu(self):
+        """Bare 'board edit' (no '#'), not just 'board #edit' -- every
+        other sub-action (post/reply/delete/rn/ra/sa/ld) is a bare
+        positional word, so '#edit' alone was the one requiring the '#'
+        cue. Before this was fixed, bare 'edit' matched none of the
+        sub== checks and silently fell through to the plain listing --
+        indistinguishable from bare 'board', with no error and no hint
+        that '#edit' was needed."""
+        ctx = make_ctx(player=_FakePlayer(admin=True), prompts=[''])
+        result = run(BoardCommand().execute(ctx, 'edit'))
+        self.assertTrue(result.success)
+        self.assertIn('Board & SIG Editor', str(ctx.prompt.call_args))
+
+    def test_bare_edit_denied_for_non_admin(self):
+        ctx = make_ctx(player=_FakePlayer(admin=False))
+        result = run(BoardCommand().execute(ctx, 'edit'))
+        self.assertFalse(result.success)
+        self.assertEqual(result.error, 'permission_denied')
+
 
 class TestDelete(BoardCommandTestCase):
     def test_non_admin_cannot_delete(self):

--- a/server/tests/social/test_news_command.py
+++ b/server/tests/social/test_news_command.py
@@ -189,14 +189,14 @@ class TestReadOne(NewsCommandTestCase):
 class TestAdminGating(NewsCommandTestCase):
     def test_non_admin_cannot_post(self):
         ctx = make_ctx(player=_FakePlayer(admin=False))
-        result = run(NewsCommand().execute(ctx, 'post'))
+        result = run(NewsCommand().execute(ctx, '#post'))
         self.assertFalse(result.success)
         self.assertEqual(result.error, 'permission_denied')
 
     def test_non_admin_cannot_delete(self):
         self._seed([{'id': 1, 'title': 'X', 'body': [], 'lifetime': 'permanent'}])
         ctx = make_ctx(player=_FakePlayer(admin=False))
-        result = run(NewsCommand().execute(ctx, 'delete', '1'))
+        result = run(NewsCommand().execute(ctx, '#delete', '1'))
         self.assertFalse(result.success)
         self.assertEqual(result.error, 'permission_denied')
 
@@ -205,7 +205,7 @@ class TestAdminGating(NewsCommandTestCase):
             player=_FakePlayer(admin=True),
             prompts=['Server Maintenance', 'permanent', 'We will be down Friday.', '.s'],
         )
-        result = run(NewsCommand().execute(ctx, 'post'))
+        result = run(NewsCommand().execute(ctx, '#post'))
         self.assertTrue(result.success)
         items = news_store.load_news(self.path)
         self.assertEqual(len(items), 1)
@@ -223,7 +223,7 @@ class TestAdminGating(NewsCommandTestCase):
             prompts=['Server Maintenance', 'c', 'Server Maintenance II',
                      'permanent', 'A brand new item.', '.s'],
         )
-        result = run(NewsCommand().execute(ctx, 'post'))
+        result = run(NewsCommand().execute(ctx, '#post'))
         self.assertTrue(result.success)
         items = news_store.load_news(self.path)
         self.assertEqual(len(items), 2)
@@ -236,7 +236,7 @@ class TestAdminGating(NewsCommandTestCase):
             player=_FakePlayer(admin=True),
             prompts=['server maintenance', ''],  # bare Enter -- abort at the prompt
         )
-        result = run(NewsCommand().execute(ctx, 'post'))
+        result = run(NewsCommand().execute(ctx, '#post'))
         self.assertFalse(result.success)
         items = news_store.load_news(self.path)
         self.assertEqual(len(items), 1)  # nothing new posted
@@ -248,7 +248,7 @@ class TestAdminGating(NewsCommandTestCase):
             player=_FakePlayer(admin=True),
             prompts=['Server Maintenance', 'e', 'New Title', '', 'kept body', '.s'],
         )
-        result = run(NewsCommand().execute(ctx, 'post'))
+        result = run(NewsCommand().execute(ctx, '#post'))
         self.assertTrue(result.success)
         items = news_store.load_news(self.path)
         self.assertEqual(len(items), 1)  # still just the one item -- edited, not duplicated
@@ -257,9 +257,60 @@ class TestAdminGating(NewsCommandTestCase):
     def test_admin_can_delete(self):
         self._seed([{'id': 1, 'title': 'X', 'body': [], 'lifetime': 'permanent'}])
         ctx = make_ctx(player=_FakePlayer(admin=True))
-        result = run(NewsCommand().execute(ctx, 'delete', '1'))
+        result = run(NewsCommand().execute(ctx, '#delete', '1'))
         self.assertTrue(result.success)
         self.assertEqual(news_store.load_news(self.path), [])
+
+    def test_admin_can_edit(self):
+        self._seed([{'id': 1, 'title': 'Old Title', 'body': ['old body'],
+                      'lifetime': 'permanent', 'posted_at': '2026-01-01T00:00:00'}])
+        ctx = make_ctx(
+            player=_FakePlayer(admin=True),
+            prompts=['New Title', '', 'new body', '.s'],
+        )
+        result = run(NewsCommand().execute(ctx, '#edit', '1'))
+        self.assertTrue(result.success)
+        items = news_store.load_news(self.path)
+        self.assertEqual(items[0]['title'], 'New Title')
+
+
+class TestBareSubwordsRejected(NewsCommandTestCase):
+    """'post'/'edit'/'delete' are '#'-only switches -- unlike board.py's
+    bare 'edit' (which is deliberately accepted, since it has no unsafe
+    fallthrough), a bare word here used to silently redisplay the plain
+    listing instead of erroring or hinting at the right syntax. These
+    lock in the explicit "needs a '#'" hint added alongside the #-only
+    conversion, so a regression back to silent fallthrough is caught."""
+
+    def test_bare_post_hints_at_hash_form(self):
+        ctx = make_ctx(player=_FakePlayer(admin=True))
+        result = run(NewsCommand().execute(ctx, 'post'))
+        self.assertFalse(result.success)
+        self.assertEqual(result.error, 'missing_hash')
+        sent = ' '.join(str(c) for c in ctx.send.await_args_list)
+        self.assertIn('#post', sent)
+
+    def test_bare_edit_hints_at_hash_form(self):
+        self._seed([{'id': 1, 'title': 'X', 'body': [], 'lifetime': 'permanent'}])
+        ctx = make_ctx(player=_FakePlayer(admin=True))
+        result = run(NewsCommand().execute(ctx, 'edit', '1'))
+        self.assertFalse(result.success)
+        self.assertEqual(result.error, 'missing_hash')
+        sent = ' '.join(str(c) for c in ctx.send.await_args_list)
+        self.assertIn('#edit', sent)
+        # The real regression check: the item must be untouched.
+        self.assertEqual(news_store.load_news(self.path)[0]['title'], 'X')
+
+    def test_bare_delete_hints_at_hash_form(self):
+        self._seed([{'id': 1, 'title': 'X', 'body': [], 'lifetime': 'permanent'}])
+        ctx = make_ctx(player=_FakePlayer(admin=True))
+        result = run(NewsCommand().execute(ctx, 'delete', '1'))
+        self.assertFalse(result.success)
+        self.assertEqual(result.error, 'missing_hash')
+        sent = ' '.join(str(c) for c in ctx.send.await_args_list)
+        self.assertIn('#delete', sent)
+        # The real regression check: the item must still be there.
+        self.assertEqual(len(news_store.load_news(self.path)), 1)
 
 
 if __name__ == '__main__':

--- a/server/tools/bot_editor_recovery_demo.py
+++ b/server/tools/bot_editor_recovery_demo.py
@@ -8,7 +8,7 @@ Two phases against the real running server (default port 34083, same as
 simple_server.py's live JSON port -- NOT a throwaway test server, since
 this needs to actually trigger a real SHUTDOWN):
 
-  --phase crash    Connection A (botdummy) starts 'news post', types a
+  --phase crash    Connection A (botdummy) starts 'news #post', types a
                     title/lifetime/body line, but never saves. Connection
                     B (botlasso) issues 'shutdown #time now', which fires
                     Server.graceful_shutdown() and (per this feature)
@@ -108,7 +108,7 @@ async def phase_crash(host, port):
     a_reader, a_writer = await _login(host, port, 'botdummy', load_password('botdummy'))
     b_reader, b_writer = await _login(host, port, 'botlasso', load_password('botlasso'))
 
-    await _say('A', a_writer, a_reader, 'news post')
+    await _say('A', a_writer, a_reader, 'news #post')
     await _say('A', a_writer, a_reader, 'Recovery Demo')          # title
     await _say('A', a_writer, a_reader, 'permanent')              # lifetime
     await _say('A', a_writer, a_reader, 'Testing crash recovery.')  # body line

--- a/server/tools/bot_text_editor_news.py
+++ b/server/tools/bot_text_editor_news.py
@@ -106,7 +106,7 @@ async def main(host: str, port: int, user: str, password: str) -> None:
     ])
 
     await _run_script(writer, reader, [
-        ('news post', 'game'),
+        ('news #post', 'game'),
         ('Per-viewer rendering test', 'game'),   # title
         ('permanent', 'game'),                   # lifetime
         ('Plain top line.', 'game'),


### PR DESCRIPTION
## Summary

Found while auditing the codebase's `#<switch>` convention (`Command.parse_args()` splits args into `(positional, switches)`, where switches are `#`-prefixed tokens):

- **`board.py`**: the admin settings menu was reachable only via `board #edit`, while every other sub-action (`post`/`reply`/`delete`/`rn`/`ra`/`sa`/`ld`) is a bare positional word. Typing the natural `board edit` (no `#`) silently fell through to the plain listing — no error, no hint that `#edit` was needed. Fixed by accepting bare `edit` too, matching the style of every other sub-action. The `#edit` switch spelling still works.
- **`map.py`/`teleport.py`**: both manually checked `args[0].lower().lstrip('#')` instead of using `parse_args()`'s switches/positional split like `board.py`/`groups.py`/`whereat.py`/`reload.py` do. Converted both to the same `parse_args()`-based `sub`/`rest` extraction, de-duplicating three copies of the same check in `map.py` and dropping a redundant second `parse_args()` call in `teleport.py`. No behavior change — both commands' documented (or, for teleport, structurally necessary) bare-or-`#` dual-form tolerance is preserved exactly.
- **`news.py`/`banner_edit.py`**: the opposite problem — `post`/`edit`/`delete` (news.py) and `list`/`edit` (banner_edit.py) were bare positional words with **no** `#` option at all, inconsistent with `reload.py`/`groups.py`/`whereat.py`/`board.py`'s own `#edit`. Converted to `#`-only switches (`news #post`, `news #edit <id>`, `news #delete <id>`, `banner #edit <name>`, `banner #list`) — a deliberate breaking change per an explicit "switches should only ever be spelled with `#`, no bare-word alternative" call. A bare `edit`/`delete`/`post`/`list` now gets an explicit "needs a `#`" hint instead of silently falling through to the wrong screen (the same board.py-style trap, relocated).

Note: `ban.py` has the same dual-dispatch shape (bare action + `#view`/`#list` switch) and was investigated, but a fix was explicitly declined — switches there stay `#`-only with no bare-word acceptance, so it's unchanged in this PR.

## Fallout fixed

- `commands/edit.py`'s crash-recovery hint (actual player-facing text) now says `news #edit` instead of `news edit`.
- Two live-server bot testing scripts (`tools/bot_editor_recovery_demo.py`, `tools/bot_text_editor_news.py`) updated to `news #post` — these would have silently broken against the real server otherwise.
- `MECHANICS.md` docs updated.

## Testing

- Added regression tests throughout: bare `board edit` reaches the settings menu for admins / denied for non-admins; `map.py`'s bare-vs-`#` forms for `grid`/`overview`/`visited` (previously untested); `teleport.py`'s missing bare-`list`/`show` case; `news.py`'s new `#edit` coverage plus a `TestBareSubwordsRejected` class locking in the new hint message; `banner_edit.py` had **zero** existing test coverage — added `tests/admin/test_banner_edit.py` from scratch (9 tests).
- Full suite (`pytest -q`): 4669 passed, 2 skipped, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)